### PR TITLE
chore: remove jq dependency, bump to 1.6.1

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,14 +6,14 @@
   },
   "metadata": {
     "description": "Official Bright Data plugin for Claude Code - Web scraping, search, structured data extraction, and Python SDK",
-    "version": "1.6.0"
+    "version": "1.6.1"
   },
   "plugins": [
     {
       "name": "brightdata-plugin",
       "source": "./",
       "description": "Web scraping, Google search, structured data extraction, and MCP server integration powered by Bright Data. Includes 11 skills: scrape any webpage as markdown (with bot detection/CAPTCHA bypass), search Google with structured JSON results, extract data from 40+ websites (Amazon, LinkedIn, Instagram, TikTok, YouTube, and more), orchestrate Bright Data's 60+ MCP tools, Bright Data CLI for terminal-based scraping/search/data extraction/zone management, real-time competitive intelligence (competitor snapshots, pricing comparison, review mining, hiring signals, market landscape mapping), built-in best practices for Web Unlocker, SERP API, Web Scraper API, and Browser API, Python SDK best practices for the brightdata-sdk package, scraper builder for any website, design system mirroring, and Browser API session debugging.",
-      "version": "1.6.0",
+      "version": "1.6.1",
       "author": {
         "name": "Bright Data",
         "email": "support@brightdata.com",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "brightdata-plugin",
   "description": "Web scraping, Google search, structured data extraction, and MCP server integration powered by Bright Data. Includes 11 skills: scrape any webpage as markdown (with bot detection/CAPTCHA bypass), search Google with structured JSON results, extract data from 40+ websites (Amazon, LinkedIn, Instagram, TikTok, YouTube, and more), orchestrate Bright Data's 60+ MCP tools, Bright Data CLI for terminal-based scraping/search/data extraction/zone management, real-time competitive intelligence (competitor snapshots, pricing comparison, review mining, hiring signals, market landscape mapping), built-in best practices for Web Unlocker, SERP API, Web Scraper API, and Browser API, Python SDK best practices for the brightdata-sdk package, scraper builder for any website, design system mirroring, and Browser API session debugging.",
-  "version": "1.6.0",
+  "version": "1.6.1",
   "author": {
     "name": "Bright Data",
     "email": "support@brightdata.com",
@@ -42,8 +42,5 @@
     "market-research",
     "competitor-analysis",
     "pricing-intelligence"
-  ],
-  "dependencies": [
-    "jq"
   ]
 }


### PR DESCRIPTION
## Summary
- Drop `jq` from `plugin.json` dependencies (validated as no longer required)
- Bump `plugin.json` and `marketplace.json` to 1.6.1

## Test plan
- [x] `plugin.json` and `marketplace.json` parse as valid JSON
- [ ] Install plugin in a fresh Claude Code env and confirm skills load without a `jq` binary