### PR TITLE
feat: add scraper-studio skill

### DIFF
--- a/skills/scraper-studio/SKILL.md
+++ b/skills/scraper-studio/SKILL.md
@@ -1,0 +1,247 @@
+---
+name: scraper-studio
+description: "Build and run AI-generated Bright Data scrapers from the terminal via `bdata scraper create` and `bdata scraper run`. Use this skill whenever the user wants to generate a scraper from a natural-language description, build a custom scraper without writing code, turn a URL + plain-English description into a reusable scraper, or run an existing Bright Data collector against a URL and get the data back. Triggers on phrases like 'build me a scraper for', 'create a scraper that extracts', 'generate a scraper from a description', 'turn this URL into a scraper', 'run this scraper on', 'run my collector', 'scraper studio', `scraper create`, `scraper run`, `collector_id`, `automate_template`, or `/dca/`. Covers the AI flow (template create → trigger AI generation → poll progress), the run flow (async + poll by default, `--sync` for fast pages), and the silent auto-fallback to the batch endpoint when a URL expands past the realtime page limit. Requires the Bright Data CLI."
+---
+
+# Bright Data — Scraper Studio
+
+Build a scraper from natural language, then run it. Two commands live in this skill:
+
+- **`bdata scraper create <url> <description>`** — describe what you want in plain English; Bright Data's AI Flow generates a scraper template and returns a `collector_id`.
+- **`bdata scraper run <collector_id> <url>`** — run that collector (or any existing one from the Bright Data web UI) against a URL and get the extracted data back.
+
+**The bridge between the two is `collector_id`.** It is printed by `create` and consumed by `run`. Always save it.
+
+For pre-built scrapers on platforms like Amazon, LinkedIn, TikTok, Instagram, YouTube, Reddit, etc., **stop and use the [`data-feeds`](../data-feeds/SKILL.md) skill instead** — those scrapers already exist, are faster, cheaper, and more reliable than building a new one. Use Scraper Studio when no pre-built scraper covers the target site, or when the user wants a custom shape of output for an existing platform.
+
+## Setup gate (run first)
+
+```bash
+if ! command -v bdata >/dev/null 2>&1; then
+    echo "bdata CLI not installed — see bright-data-best-practices/references/cli-setup.md"
+elif ! bdata zones >/dev/null 2>&1; then
+    echo "bdata not authenticated — run: bdata login  (or: bdata login --device for SSH)"
+fi
+```
+
+Halt and route to setup if either check fails. Both commands require an authenticated CLI.
+
+## Pick your path
+
+| Situation | Action |
+|---|---|
+| User describes data they want from a URL, no scraper exists yet | `bdata scraper create <url> "<description>"` → save the `collector_id` |
+| User has a `collector_id` and wants data from a URL | `bdata scraper run <collector_id> <url>` (default async + poll) |
+| Page is small and you want fast feedback (≤ ~50 s) | `bdata scraper run … --sync` |
+| Site is a known platform (Amazon, LinkedIn, TikTok, …) | **stop — use `data-feeds` skill** |
+| You want SERP / discovery, not extraction | **use `search` skill** |
+| You want a one-off raw page fetch | **use `scrape` skill** |
+
+---
+
+## Action 1 — `scraper create`
+
+Generate a scraper from a URL + plain-English description.
+
+```bash
+bdata scraper create <url> "<description>" [--name <name>] \
+    [--deliver-webhook <url>] [--timeout <seconds>] \
+    [--json | --pretty] [-o <path>] [--timing] [-k <api-key>]
+```
+
+The description is the most important input. A good description names every field you want and any conditions on how to find them. See [references/prompts.md](references/prompts.md) for examples of strong vs. weak descriptions.
+
+```bash
+# Minimal
+bdata scraper create https://example.com/product/1 \
+    "Extract title, price, currency, image URL, and availability \
+     from this product page. If the price has a strike-through \
+     original price, capture both as price and original_price."
+
+# Save the full AI output for inspection
+bdata scraper create https://example.com/product/1 \
+    "Extract title, price, and image URL" \
+    --name product-scraper-v1 \
+    --pretty -o create.json
+```
+
+### What happens under the hood
+
+`create` chains three Bright Data API calls — surface this to the user so they can debug from logs:
+
+1. **`POST /dca/collector`** — creates an empty scraper template with a stub webhook delivery target (`https://example.com/webhook` by default). Returns a `collector_id` like `c_mp3tuab31lswoxvpws`.
+2. **`POST /dca/collectors/{collector_id}/automate_template`** — triggers Bright Data's AI Flow with the description + URL.
+3. **`GET .../automate_template/progress`** (polled) — waits for `status: "done"`. Generation typically takes **5–10 minutes** for moderately complex pages.
+
+### Critical: hold the `collector_id`
+
+Every failure path in `create` (AI trigger fails, polling times out, generation finishes with `status: "failed"`) **still leaves a partially-built collector** at the printed `collector_id`. Always tell the user the id is recoverable — they can:
+
+- Open `https://brightdata.com/cp/scrapers/{collector_id}` to finish or inspect it in the web UI.
+- Re-trigger generation programmatically against the same id.
+- Delete it from the UI if they want a clean slate.
+
+Never claim "create failed, start over" without surfacing the `collector_id` from the response.
+
+### `--timeout` — default 600 s
+
+AI generation can run 5–10 min for complex pages. If the page is simple, the default is plenty. For an elaborate description on a heavy site, raise it:
+
+```bash
+bdata scraper create https://complex-site.com/page \
+    "Extract all 30 fields …" \
+    --timeout 1200
+```
+
+On `Timeout after N seconds waiting for AI generation`, the `collector_id` is still printed. Re-check progress in the web UI rather than re-running `create` (which builds a new collector).
+
+### `--deliver-webhook` — placeholder by default
+
+The CLI sets a stub webhook (`https://example.com/webhook`). This satisfies the API contract but **does not deliver anything**. For CLI use, leave the stub — you'll fetch results synchronously via `scraper run`. The real delivery target can be reconfigured in the [Bright Data web UI](https://brightdata.com/cp/scrapers) if the user wants webhook delivery for production runs.
+
+---
+
+## Action 2 — `scraper run`
+
+Execute a scraper against a URL.
+
+```bash
+bdata scraper run <collector_id> <url> [--sync [--sync-timeout 25-50]] \
+    [--timeout <seconds>] [--name <name>] [--version <version>] \
+    [--json | --pretty] [-o <path>] [--timing] [-k <api-key>]
+```
+
+### Choosing the run mode
+
+```
+                ┌─────────────────────────────────────────────────┐
+                │ Expected to finish in ≤ ~50 seconds?            │
+                └─────────────────────────────────────────────────┘
+                 yes                                       no
+                  │                                         │
+                  ▼                                         ▼
+       ┌──────────────────────┐                ┌────────────────────────┐
+       │   --sync             │                │  default (no flag)     │
+       │   /dca/crawl         │                │  trigger_immediate +   │
+       │   one-shot, 25–50 s  │                │  poll get_result       │
+       └──────────────────────┘                └────────────────────────┘
+                  │
+                  │  on 202 timeout: response_id is printed —
+                  │  re-run WITHOUT --sync to poll for it
+                  ▼
+            (cleanly fall back to async)
+```
+
+| Mode | Endpoint | When to use |
+|---|---|---|
+| **Default (async + poll)** | `/dca/trigger_immediate` → poll `/dca/get_result` | Anything you expect to take more than ~50 s, anything paginated, anything you're not sure about. This is the safe default. |
+| **`--sync`** | `/dca/crawl` | Single-page extractions you expect to complete in under 50 s. Faster path: one request, no polling. |
+
+```bash
+# Default — async + poll (recommended for most cases)
+bdata scraper run c_mp3tuab31lswoxvpws https://www.amazon.com/dp/B08N5WRWNW
+
+# Pretty-printed, saved to disk
+bdata scraper run c_mp3tuab31lswoxvpws https://www.amazon.com/dp/B08N5WRWNW \
+    --pretty -o product.json
+
+# Sync mode for a fast page
+bdata scraper run c_mp3tuab31lswoxvpws https://example.com/p/1 --sync
+
+# Sync with a tighter server timeout
+bdata scraper run c_mp3tuab31lswoxvpws https://example.com/p/1 \
+    --sync --sync-timeout 30
+```
+
+### `--sync-timeout` is bounded to 25–50
+
+Anything outside that range exits with `--sync-timeout must be between 25 and 50 seconds`. Default is 50. Use values < 50 only when you want to fail fast and fall back to async on slow pages.
+
+### `--sync` timeout recovery
+
+If `/dca/crawl` server-side times out, it returns 202 with `{"error":"crawl_results_timeout","response_id":"r_late_..."}`. The CLI surfaces the `response_id` and exits with a "Re-run without --sync" message. Do exactly that — drop `--sync` and re-run the same command; the default async path will poll `/dca/get_result` for the existing `response_id`. **Do not** treat sync timeout as a hard failure.
+
+### Silent auto-fallback to batch (paginated / large pages)
+
+When a single URL expands to more pages than the realtime job limit allows (paginated listings, infinite scroll, "all reviews" pages, etc.), the realtime endpoints return an error like:
+
+```
+Request generated 501 pages and exceeded realtime job limit of 51 pages
+```
+
+The CLI detects this and **automatically falls back** to the batch flow (`/dca/trigger` → poll `/dca/dataset`). A one-line notice is printed. No flag is needed. Batch jobs use a longer poll interval (10 s) and a longer default timeout (1 hour).
+
+If the user only sees the notice and a long wait, that is expected — large jobs take time. Do not "fix" the fallback by switching APIs or restructuring the scraper; let it run.
+
+### `--name` and `--version`
+
+- `--name <name>` — tag this run in the Bright Data dashboard. Useful when you're scripting many runs and want to find one later.
+- `--version <version>` — pin a specific scraper version (commonly `dev` when iterating in the web UI). Omit to use the latest published version.
+
+---
+
+## Full create-then-run workflow
+
+Capture the `collector_id` cleanly with `jq`, then chain into `run`:
+
+```bash
+# 1. Create the scraper, save the AI output, extract the collector_id
+bdata scraper create https://example.com/product/1 \
+    "Extract title, price, currency, image URL, and availability" \
+    --pretty -o create.json
+
+# 2. Pull the collector_id (or copy from the human-readable summary)
+COLLECTOR_ID=$(jq -r '.collector_id // .id' create.json)
+echo "Built: $COLLECTOR_ID"
+
+# 3. Run it on each URL you want extracted
+for url in $(cat urls.txt); do
+    bdata scraper run "$COLLECTOR_ID" "$url" --json -o "out/${url//[\/:.]/_}.json"
+done
+```
+
+For more end-to-end recipes (batch run loops, error recovery, web-UI handoff), see [references/recipes.md](references/recipes.md).
+
+---
+
+## Common mistakes
+
+1. **Inventing command names.** The commands are exactly `bdata scraper create` and `bdata scraper run`. There is no `bdata generate`, no `bdata scrape-batch`, no `bdata data`, no `bdata build`. If you're tempted to use one of those, you're hallucinating — run `bdata scraper --help` to verify.
+
+2. **Re-running `create` after a timeout.** Generation creates a fresh collector every time. If polling times out, the half-built collector is still printed in the error output. Resume it in the web UI or wait and re-poll — don't burn another collector.
+
+3. **Defaulting to `--sync` for everything.** Sync caps at 50 s server-side. Any paginated page or heavy SPA will time out. Default async is the right choice unless you specifically know the page is small.
+
+4. **Skipping Scraper Studio for known platforms.** If the target is Amazon, LinkedIn, TikTok, Instagram, YouTube, Reddit, etc., the [`data-feeds`](../data-feeds/SKILL.md) skill exposes pre-built scrapers that are faster, cheaper, and more reliable. Only build a custom scraper when no pre-built one exists for the site, or when the user explicitly wants a custom output shape.
+
+5. **Treating sync timeout as failure.** A `--sync` 202 timeout returns a valid `response_id` — the job is still running on the backend. Re-run the same command without `--sync` to pick it up.
+
+6. **Throwing away `collector_id` / `response_id` on error.** The CLI prints them in every failure path on purpose. Both are recoverable via the API and the web UI. Always surface them to the user.
+
+7. **Trying to disable the batch auto-fallback.** It has no flag. The fallback is the correct behavior when a URL expands past the realtime page limit. Let it run.
+
+8. **Vague descriptions in `create`.** A description like "scrape the page" produces a generic scraper. Name every field, name conditions ("if there's a sale price, capture both"), name disambiguators ("the price near the title, not in the recommendations sidebar"). See [references/prompts.md](references/prompts.md).
+
+---
+
+## Troubleshooting
+
+| Symptom | Cause | Fix |
+|---|---|---|
+| `bdata: command not found` | CLI not installed | See [`brightdata-cli`](../brightdata-cli/SKILL.md) for install. |
+| `Invalid or expired API key` | Not logged in | `bdata login` (or `bdata login --device` for SSH). |
+| `create` returns no `id` | API call failed before template was created | Check `--timing` output for the failing request; verify network and account status. |
+| `Timeout after 600 seconds waiting for AI generation` | Page is complex; default poll exceeded | The `collector_id` is still printed. Open it in the web UI; or re-run with `--timeout 1200`. |
+| `status: "failed"` from progress poll | AI Flow couldn't build the template | Improve the description — be more specific about fields and selectors. Try again with a cleaner URL (e.g. a canonical product page, not a search result). |
+| `--sync` 202 with `crawl_results_timeout` | Page took > sync server cap | Re-run **without** `--sync` to poll `/dca/get_result` for the printed `response_id`. |
+| `--sync-timeout must be between 25 and 50 seconds` | Out-of-range value | Use a value in `[25, 50]`. |
+| `Request generated N pages and exceeded realtime job limit` | URL expanded too far | This is **handled automatically** — wait for the batch fallback notice and let it poll. |
+| No data returned, just `[]` or `{}` | Selectors didn't match | The scraper template ran but extracted nothing. Open `https://brightdata.com/cp/scrapers/{collector_id}` to inspect/edit; or rebuild with a tighter description. |
+
+---
+
+## Reference files
+
+- **[references/prompts.md](references/prompts.md)** — How to write a description for `scraper create` that the AI Flow can act on. Examples of strong vs. weak descriptions, field-listing patterns, and conditional rules.
+- **[references/recipes.md](references/recipes.md)** — End-to-end recipes: capture `collector_id` from create, batch run a list of URLs, handle sync→async fallback, recover from a failed create, list scrapers from the dashboard.
+- **[references/api-flow.md](references/api-flow.md)** — Exact REST endpoints, payloads, and status sentinels the CLI uses (`/dca/collector`, `/dca/collectors/{id}/automate_template`, `/dca/trigger_immediate`, `/dca/get_result`, `/dca/crawl`, `/dca/trigger`, `/dca/dataset`). Read this when debugging unexpected CLI output or when the user wants to hit the API directly.

--- a/skills/scraper-studio/references/api-flow.md
+++ b/skills/scraper-studio/references/api-flow.md
@@ -1,0 +1,172 @@
+# Scraper Studio — underlying REST flow
+
+Read this when debugging unexpected CLI output, when the user wants to hit the API directly, or when you need to understand which artefact (`collector_id` vs `response_id`) is recoverable from which failure path.
+
+All endpoints are under `https://api.brightdata.com`. Auth header: `Authorization: Bearer $BRIGHTDATA_API_KEY`.
+
+## `scraper create` — three chained calls
+
+### 1. Create template
+
+```
+POST /dca/collector
+{
+  "name": "cli-scraper-1747146000",        // auto-generated unless --name
+  "deliver": {
+    "type": "webhook",
+    "endpoint": "https://example.com/webhook",   // stub unless --deliver-webhook
+    "filename": {"template": "data", "extension": "json"}
+  }
+}
+```
+
+Returns:
+```json
+{ "id": "c_mp3tuab31lswoxvpws", "name": "cli-scraper-1747146000", ... }
+```
+
+The `id` is the **`collector_id`**. Hold onto it from this point forward — every subsequent failure path can still surface it.
+
+### 2. Trigger AI generation
+
+```
+POST /dca/collectors/{collector_id}/automate_template
+{
+  "description": "Extract title, price ...",
+  "urls": ["https://example.com/product/1"]      // CLI wraps the single URL in an array
+}
+```
+
+Returns:
+```json
+{ "id": "ia_xyz...", "queued": false }
+```
+
+### 3. Poll progress
+
+```
+GET /dca/collectors/{collector_id}/automate_template/progress
+```
+
+Returns one of:
+```json
+{ "status": "queued",  "completed_steps": [] }
+{ "status": "planner", "completed_steps": ["a"] }
+{ "status": "running", "completed_steps": ["a","b"], "step": "preview_picker" }
+{ "status": "done",    "completed_steps": ["a","b","c","d"], ... }
+{ "status": "failed",  "completed_steps": [...], "error": "..." }
+```
+
+The CLI treats anything other than `done` (and other than `failed`) as still running and polls until `done`, timeout, or a non-`done` terminal status. The default poll timeout is 600 seconds (`--timeout`).
+
+**Recoverability:** all three calls can fail. In every case the `collector_id` from step 1 is still valid — open `https://brightdata.com/cp/scrapers/{collector_id}` to inspect or finish manually.
+
+---
+
+## `scraper run` — three possible paths
+
+### Path A — default async + poll
+
+```
+POST /dca/trigger_immediate?collector={collector_id}&name=...&version=...
+{
+  "url": "https://example.com/page"
+}
+```
+
+Returns:
+```json
+{ "response_id": "r_abc..." }
+```
+
+The CLI then polls:
+```
+GET /dca/get_result?response_id={response_id}
+```
+
+Response classification:
+- **200 + JSON body that isn't `null` and isn't `{"pending":true}`** → ready, parse and return.
+- **200 + empty / whitespace / `null` / `{"pending":true,...}`** → still pending.
+- **202** → still pending.
+- **4xx / 5xx** → pending (CLI keeps trying briefly; persistent failure surfaces via the poll timeout).
+
+Default poll timeout: 600 seconds (`--timeout`).
+
+### Path B — `--sync` (`/dca/crawl`)
+
+One-shot synchronous extraction. Cap is **25–50 seconds** server-side; the CLI sends `timeout=<sync-timeout>s` (default 50).
+
+```
+POST /dca/crawl?collector={collector_id}&timeout=50s&name=...&version=...
+{
+  "url": "https://example.com/page"
+}
+```
+
+Outcomes:
+- **200 + body** → ready, return.
+- **202 + `{"error":"crawl_results_timeout","response_id":"r_late_..."}`** → server-side timeout. CLI prints the `response_id` and tells the user to **re-run without `--sync`**. The same request can be picked up async by polling `/dca/get_result?response_id=...` (which is what `bdata scraper run <collector_id> <url>` will do under the hood — though it triggers a new request, so for true reuse of the existing `response_id` you'd call `get_result` directly).
+- Other non-200 → surfaced as an error.
+
+### Path C — auto-fallback to batch
+
+Triggered when path A or B returns a body that contains the marker `realtime job limit` (case-insensitive). Typically looks like:
+
+```json
+[{
+  "input": {"url": "https://example.com/listing"},
+  "error": "Request generated 501 pages and exceeded realtime job limit of 51 pages"
+}]
+```
+
+The CLI then makes:
+
+```
+POST /dca/trigger?collector={collector_id}&name=...&version=...
+[
+  { "url": "https://example.com/listing" }   // body is an array
+]
+```
+
+Returns:
+```json
+{ "collection_id": "d_batch_...", "start_eta": "2026-05-13T12:00:00Z" }
+```
+
+Then polls:
+```
+GET /dca/dataset?id={collection_id}
+```
+
+Dataset response classification:
+- **200 + array body** → ready.
+- **200 + `{"status":"building"}`** → pending.
+- **202** → pending.
+- **Empty body** → pending.
+
+Batch defaults: 10 s poll interval, 3600 s (1 hour) timeout.
+
+---
+
+## Two artefacts, two failure recoveries
+
+| Artefact | Printed by | Used to recover via | Persists if step fails |
+|---|---|---|---|
+| `collector_id` (`c_…`) | `scraper create` step 1, every failure path of `create`, every error path of `run` | Web UI (`/cp/scrapers/{id}`), subsequent `scraper run` calls, direct API hits | yes — template exists even if AI generation never finished |
+| `response_id` (`r_…`) | async path A trigger response, `--sync` 202 timeout | `GET /dca/get_result?response_id=...` | yes — server keeps the running job |
+
+The CLI is engineered so neither artefact ever silently disappears — both are printed in every failure path. If the user reports "the command failed", first thing to ask: "what `collector_id` / `response_id` did it print?"
+
+---
+
+## Status sentinels in the CLI (for reading source / logs)
+
+The CLI uses a few internal string sentinels you may see in `--timing` or debug output:
+
+| Sentinel | Meaning |
+|---|---|
+| `__running__` | Generation progress is not yet `done` (matches `queued`, `planner`, `running`, etc.) |
+| `__ready__` | Result body is parseable and non-empty |
+| `__pending__` | Result body is empty / `null` / `{"pending":true}` / 202 / 4xx / 5xx — poll again |
+
+These are implementation details — don't expose them to end users.

--- a/skills/scraper-studio/references/prompts.md
+++ b/skills/scraper-studio/references/prompts.md
@@ -1,0 +1,152 @@
+# Writing descriptions for `scraper create`
+
+The description you pass to `bdata scraper create <url> "<description>"` is the only signal the AI Flow has about what to extract. It is not a search query — it is a spec. Treat it like one.
+
+## The minimal contract
+
+Every good description answers three questions:
+
+1. **What fields?** Name each one explicitly.
+2. **From where on the page?** Disambiguate when a value could appear in multiple places.
+3. **What conditions / shape?** Handle variants (sale price vs regular price, missing fields, repeating items).
+
+## Strong vs. weak — side by side
+
+### Product page
+
+**Weak (avoid):**
+```
+"scrape this product page"
+```
+
+The AI has to guess every field. Output will be inconsistent across runs.
+
+**Stronger:**
+```
+"Extract product details from this page."
+```
+
+Slightly better, still too vague. Which details? In what shape?
+
+**Strong:**
+```
+"Extract the following fields from this product page:
+ - title: the main product title near the top of the page
+ - price: the current price shown to the buyer (number + currency)
+ - original_price: the strike-through price, if present; otherwise null
+ - currency: ISO 4217 code (e.g. USD, EUR)
+ - image_url: the main product image, not the thumbnail gallery
+ - availability: in_stock / out_of_stock / preorder
+ - rating: average customer rating (number, 0–5)
+ - review_count: total number of reviews"
+```
+
+Each field is named, located, and typed. The AI Flow has a clear target for every selector.
+
+### Listing / search results page
+
+**Weak:**
+```
+"scrape all products"
+```
+
+**Strong:**
+```
+"Extract the list of product cards from this search results page.
+ For each card, capture:
+ - title
+ - price
+ - image_url
+ - product_url (absolute URL)
+ - rating (if shown)
+ Skip sponsored / ad cards. Return an array, one object per card.
+ Stop at the end of the current page — do not follow pagination."
+```
+
+The "skip ads", "absolute URL", and "stop at end of page" rules are the kind of guardrails the AI Flow needs.
+
+### Article / blog post
+
+**Strong:**
+```
+"Extract the article body from this page:
+ - headline
+ - subheadline (if present)
+ - author_name
+ - published_date (ISO 8601)
+ - body_text (full article text as plain text, paragraphs joined by \n\n)
+ - tags (array of strings)
+ - hero_image_url
+ Exclude: navigation, footer, related-articles widgets, comments."
+```
+
+## Patterns that consistently improve output
+
+### Pattern 1 — name the location when ambiguous
+
+A price can appear in a recommendations sidebar, in a "frequently bought together" bundle, and on the main product. Always name *which* one.
+
+```
+"price: the main product price near the title, not the prices in
+ the recommendations sidebar or the bundle widget"
+```
+
+### Pattern 2 — handle the missing-field case explicitly
+
+```
+"original_price: the strike-through original price if a sale is
+ active; null if no sale is shown"
+```
+
+Otherwise the AI Flow might omit the field, return an empty string, or hallucinate one.
+
+### Pattern 3 — name the shape for lists
+
+```
+"reviews: array of objects, each with:
+ - author_name
+ - rating (number 0-5)
+ - body_text
+ - published_date (ISO 8601)
+ Include all reviews visible on the page."
+```
+
+### Pattern 4 — exclude noise
+
+For long pages with lots of nav / footer / ads, list what to skip:
+
+```
+"Exclude: site navigation, footer, cookie banner,
+ related-products widget, recently-viewed widget,
+ sponsored content blocks."
+```
+
+### Pattern 5 — pin the data type
+
+Numbers, dates, booleans, and URLs are the four types most often returned as strings by default. Pin them:
+
+```
+"price: number (not string), in USD"
+"published_date: ISO 8601 (e.g. 2026-05-13T10:00:00Z)"
+"in_stock: boolean"
+"product_url: absolute URL (resolve relative paths)"
+```
+
+## Description anti-patterns
+
+| Don't | Why |
+|---|---|
+| `"scrape this page"` | No fields named. AI has to invent the schema. |
+| `"give me everything"` | Output is unpredictable and useless for downstream code. |
+| `"extract data"` | Same. |
+| `"like the Amazon scraper"` | The AI Flow doesn't know about other scrapers. Spell out the fields. |
+| `"return CSV"` | Output format is controlled by the run-time flags (`--json`, `-o`), not the description. The scraper always emits structured data. |
+| Multi-paragraph essays | The AI Flow performs better on structured field lists than on prose. |
+
+## Iterating on a description
+
+1. Run `create` with your first description. Save the output (`--pretty -o create.json`).
+2. `run` the resulting `collector_id` against the same URL.
+3. Inspect the data. Note what's missing, miscategorised, or duplicated.
+4. **Do not** re-run `create` immediately — open the existing collector in the web UI (`https://brightdata.com/cp/scrapers/{collector_id}`) and refine the selectors there.
+5. If the structure is fundamentally wrong, then rebuild: `create` with a sharper description (use a new `--name` to keep the old one for comparison).

--- a/skills/scraper-studio/references/recipes.md
+++ b/skills/scraper-studio/references/recipes.md
@@ -1,0 +1,126 @@
+# Scraper Studio — recipes
+
+End-to-end shell recipes. All assume `bdata` is installed and authenticated (`bdata login`).
+
+## Recipe 1 — create + run a single page
+
+```bash
+# 1. Build the scraper, save full AI output for inspection
+bdata scraper create https://example.com/product/1 \
+    "Extract title, price, currency, image URL, and availability \
+     from this product page" \
+    --name product-v1 \
+    --pretty -o create.json
+
+# 2. Pull the collector_id out of the response
+COLLECTOR_ID=$(jq -r '.collector_id // .id' create.json)
+test -n "$COLLECTOR_ID" || { echo "no collector_id"; exit 1; }
+echo "Built scraper: $COLLECTOR_ID"
+
+# 3. Run it
+bdata scraper run "$COLLECTOR_ID" https://example.com/product/2 \
+    --pretty -o product-2.json
+
+# 4. Verify
+jq 'keys' product-2.json
+```
+
+## Recipe 2 — fan out one collector over many URLs
+
+```bash
+# Assume you already have a collector_id from a previous create
+COLLECTOR_ID="c_mp3tuab31lswoxvpws"
+mkdir -p out
+
+while IFS= read -r url; do
+    [ -z "$url" ] && continue
+    # Hash the URL so filenames are safe and unique
+    hash=$(printf '%s' "$url" | md5sum | cut -c1-8)
+    echo "[$hash] $url"
+    bdata scraper run "$COLLECTOR_ID" "$url" \
+        --json -o "out/${hash}.json" \
+        || echo "  ! failed: $url" >> out/failures.log
+done < urls.txt
+
+echo "Done. $(ls out/*.json 2>/dev/null | wc -l) results, \
+$(wc -l < out/failures.log 2>/dev/null || echo 0) failures."
+```
+
+Notes:
+- Default async + poll mode (no `--sync`) is safest for batch.
+- Run sequentially unless you've confirmed your account's concurrent-job limit. Bright Data jobs are server-side; the CLI doesn't parallelize them for you.
+- For very large URL lists (100+), prefer the web UI's bulk input or the `/dca/trigger` batch endpoint directly — see [api-flow.md](api-flow.md).
+
+## Recipe 3 — try sync, fall back to async on timeout
+
+If you expect most pages to be fast but some to be slow, `--sync` gives you the speed for the common case and exits with a `response_id` you can pick up async-style for the slow ones.
+
+```bash
+COLLECTOR_ID="c_mp3tuab31lswoxvpws"
+url="https://example.com/might-be-slow"
+
+# Try sync first; capture exit code
+if ! bdata scraper run "$COLLECTOR_ID" "$url" --sync \
+        --pretty -o result.json 2> err.log; then
+    # Pull the response_id from the error output
+    response_id=$(grep -oE 'r_[a-zA-Z0-9]+' err.log | head -1)
+    if [ -n "$response_id" ]; then
+        echo "Sync timed out — polling async for $response_id"
+        # Re-run without --sync; the CLI will poll get_result
+        bdata scraper run "$COLLECTOR_ID" "$url" \
+            --pretty -o result.json
+    else
+        echo "Sync failed for non-timeout reason:" >&2
+        cat err.log >&2
+        exit 1
+    fi
+fi
+
+jq 'keys' result.json
+```
+
+## Recipe 4 — recover a half-built collector after a failed create
+
+When `create` fails or times out, the `collector_id` is still printed. You have options:
+
+```bash
+# Option A: inspect / finish in the web UI
+echo "Open: https://brightdata.com/cp/scrapers/$COLLECTOR_ID"
+
+# Option B: just try running it as-is — sometimes partial generation
+# is enough for the fields you need
+bdata scraper run "$COLLECTOR_ID" https://example.com/page --pretty
+
+# Option C: delete it (web UI) and rebuild with a sharper description
+```
+
+Do **not** re-run `bdata scraper create` against the same URL — that builds a *new* collector and leaves the half-built one orphaned in your dashboard.
+
+## Recipe 5 — large paginated page (let the auto-fallback work)
+
+```bash
+# A search-results URL that may have thousands of items
+bdata scraper run "$COLLECTOR_ID" \
+    "https://example.com/search?q=widgets&page=1..N" \
+    --pretty -o all-widgets.json
+```
+
+What to expect in the output:
+- Default realtime trigger runs first.
+- After ~one poll cycle, the CLI prints a one-line notice that it's falling back to the batch endpoint (because the URL expanded past the realtime page limit).
+- Polling switches to a 10 s interval and a 1-hour default timeout.
+- When the batch completes, the full dataset is printed / saved.
+
+If you need a longer timeout: pass `--timeout 7200` (2 hours).
+
+## Recipe 6 — pin a `dev` version while iterating in the web UI
+
+```bash
+# Edit the scraper in the dashboard, save as the dev version
+# Then run the dev version from the CLI:
+bdata scraper run "$COLLECTOR_ID" https://example.com/page \
+    --version dev --name iteration-7 \
+    --pretty
+```
+
+`--name` tags the run so you can find it later in the dashboard's run history.


### PR DESCRIPTION
## Summary

Adds a new **`scraper-studio`** skill covering the AI-generated scraper workflow shipped in [brightdata/cli#4](https://github.com/brightdata/cli/pull/4):

- `bdata scraper create <url> <description>` — build a scraper from a natural-language description
- `bdata scraper run <collector_id> <url>` — execute a collector against a URL

Pairs SKILL.md with three references:
- `prompts.md` — how to write effective descriptions for AI generation (strong vs weak examples, field-listing patterns)
- `recipes.md` — end-to-end shell recipes (create+run, batch over URLs, sync→async fallback, collector recovery)
- `api-flow.md` — underlying REST endpoints (`/dca/collector`, `automate_template`, `/dca/trigger_immediate`, `/dca/get_result`, `/dca/crawl`, `/dca/trigger`, `/dca/dataset`) and the two recoverable artefacts (`collector_id`, `response_id`)

## What the skill teaches

- The exact command names (`bdata scraper create` / `bdata scraper run`) — caught hallucinated variants like `bdata generate scraper` / `bdata scrape-batch` / `bdata data` in baseline testing
- `collector_id` is the bridge between `create` and `run` and is recoverable from every failure path
- Async + poll is the safe default for `run`; `--sync` is only for pages expected to finish in < 50 s
- The `--sync` 202 timeout returns a `response_id` and the right recovery is to re-run **without** `--sync`
- Silent auto-fallback to `/dca/trigger` + `/dca/dataset` when a URL expands past the realtime page limit — no flag needed, let it run
- Route to the [`data-feeds`](../data-feeds/SKILL.md) skill instead when the target is a known platform (Amazon, LinkedIn, TikTok, etc.) with a pre-built scraper

## Authoring approach

Followed Anthropic's [skill authoring best practices](https://platform.claude.com/docs/en/agents-and-tools/agent-skills/best-practices) and the superpowers `writing-skills` TDD discipline:

1. **RED** — ran a baseline prompt ("how do I build a Bright Data scraper from a description?") against a fresh agent without the skill. Agent invented `bdata generate scraper`, `bdata scrape-batch`, `bdata data amazon`, treated the AI scraper as a local script — every command hallucinated.
2. **GREEN** — wrote SKILL.md + references targeting those exact failures. Re-tested the same prompt with the skill loaded; agent correctly used `bdata scraper create` / `bdata scraper run`, mentioned `collector_id` as the bridge, redirected Amazon to `data-feeds`, defaulted to async.

Description sits at 976 / 1024 chars; SKILL.md is 247 lines (under 500-line target). All references stay one level deep from SKILL.md per progressive-disclosure guidance.

## Test plan

- [ ] `bdata scraper create <product-url> "<description>"` — completes, prints a `collector_id`, output matches the skill's documented shape
- [ ] `bdata scraper run <collector_id> <url>` — default async + poll path returns data
- [ ] `bdata scraper run <collector_id> <url> --sync` — fast page returns inline; slow page returns 202 + `response_id`, re-run without `--sync` picks it up
- [ ] `bdata scraper run <collector_id> <paginated-url>` — auto-fallback notice prints, batch poll runs, dataset returns
- [ ] Walk through `references/recipes.md` recipes against a live account
- [ ] Verify the routing language to `data-feeds` triggers when a user asks about an Amazon/LinkedIn URL