### PR TITLE
docs(scraper-studio): document --urls and --input-file batch flag

### DIFF
--- a/skills/scraper-studio/SKILL.md
+++ b/skills/scraper-studio/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: scraper-studio
-description: "Build and run AI-generated Bright Data scrapers from the terminal via `bdata scraper create` and `bdata scraper run`. Use this skill whenever the user wants to generate a scraper from a natural-language description, build a custom scraper without writing code, turn a URL + plain-English description into a reusable scraper, or run an existing Bright Data collector against a URL and get the data back. Triggers on phrases like 'build me a scraper for', 'create a scraper that extracts', 'generate a scraper from a description', 'turn this URL into a scraper', 'run this scraper on', 'run my collector', 'scraper studio', `scraper create`, `scraper run`, `collector_id`, `automate_template`, or `/dca/`. Covers the AI flow (template create → trigger AI generation → poll progress), the run flow (async + poll by default, `--sync` for fast pages), and the silent auto-fallback to the batch endpoint when a URL expands past the realtime page limit. Requires the Bright Data CLI."
+description: "Build and run AI-generated Bright Data scrapers from the terminal via `bdata scraper create` and `bdata scraper run`. Use this skill whenever the user wants to generate a scraper from a natural-language description, build a custom scraper without writing code, turn a URL + plain-English description into a reusable scraper, run an existing Bright Data collector against a URL, or batch-scrape a list of URLs through one collector. Triggers on phrases like 'build me a scraper for', 'create a scraper that extracts', 'generate a scraper from a description', 'turn this URL into a scraper', 'run this scraper on', 'run my collector', 'batch scrape', 'scrape these URLs', 'scrape a list of URLs', 'competitive pricing table', 'scraper studio', `scraper create`, `scraper run`, `--urls`, `--input-file`, `collector_id`, `automate_template`, or `/dca/`. Covers the AI flow (template create → trigger AI generation → poll progress), the single-URL run flow (async + poll by default, `--sync` for fast pages), the multi-URL batch flow (`--urls` / `--input-file` → one `/dca/trigger` call with array body), and the silent auto-fallback to the batch endpoint when a URL expands past the realtime page limit. Requires the Bright Data CLI."
 ---
 
 # Bright Data — Scraper Studio
@@ -31,8 +31,9 @@ Halt and route to setup if either check fails. Both commands require an authenti
 | Situation | Action |
 |---|---|
 | User describes data they want from a URL, no scraper exists yet | `bdata scraper create <url> "<description>"` → save the `collector_id` |
-| User has a `collector_id` and wants data from a URL | `bdata scraper run <collector_id> <url>` (default async + poll) |
-| Page is small and you want fast feedback (≤ ~50 s) | `bdata scraper run … --sync` |
+| User has a `collector_id` and wants data from one URL | `bdata scraper run <collector_id> <url>` (default async + poll) |
+| User has a `collector_id` and wants data from many URLs | `bdata scraper run <collector_id> --urls "u1,u2,..."` or `--input-file urls.txt` (single batch call) |
+| Page is small and you want fast feedback (≤ ~50 s, single URL) | `bdata scraper run … --sync` |
 | Site is a known platform (Amazon, LinkedIn, TikTok, …) | **stop — use `data-feeds` skill** |
 | You want SERP / discovery, not extraction | **use `search` skill** |
 | You want a one-off raw page fetch | **use `scrape` skill** |
@@ -103,13 +104,19 @@ The CLI sets a stub webhook (`https://example.com/webhook`). This satisfies the 
 
 ## Action 2 — `scraper run`
 
-Execute a scraper against a URL.
+Execute a scraper against one or more URLs.
 
 ```bash
-bdata scraper run <collector_id> <url> [--sync [--sync-timeout 25-50]] \
+bdata scraper run <collector_id> [url] \
+    [--urls "u1,u2,..." | --input-file <path>] \
+    [--sync [--sync-timeout 25-50]] \
     [--timeout <seconds>] [--name <name>] [--version <version>] \
     [--json | --pretty] [-o <path>] [--timing] [-k <api-key>]
 ```
+
+**Pick exactly one input source:** positional `<url>`, `--urls`, or `--input-file`. Combining them errors with `only one input source`.
+
+Multi-URL routes through `/dca/trigger` as a single API call with an array body — the canonical pattern from the [Scraper Studio Node](https://github.com/brightdata/bright-data-scraper-studio-nodejs-project) and [Python](https://github.com/brightdata/bright-data-scraper-studio-python-project) reference projects (`triggerWithUrls` / `trigger_with_urls`). One snapshot, one poll loop, one merged result array. **Do not hand-roll a `for url in $(cat urls.txt); do bdata scraper run ...` loop** — that's N API calls for what should be one.
 
 ### Choosing the run mode
 
@@ -134,8 +141,9 @@ bdata scraper run <collector_id> <url> [--sync [--sync-timeout 25-50]] \
 
 | Mode | Endpoint | When to use |
 |---|---|---|
-| **Default (async + poll)** | `/dca/trigger_immediate` → poll `/dca/get_result` | Anything you expect to take more than ~50 s, anything paginated, anything you're not sure about. This is the safe default. |
-| **`--sync`** | `/dca/crawl` | Single-page extractions you expect to complete in under 50 s. Faster path: one request, no polling. |
+| **Default (single URL, async + poll)** | `/dca/trigger_immediate` → poll `/dca/get_result` | Anything you expect to take more than ~50 s, anything paginated, anything you're not sure about. This is the safe default for one URL. |
+| **`--sync` (single URL)** | `/dca/crawl` | Single-page extractions you expect to complete in under 50 s. Faster path: one request, no polling. **Incompatible with multi-URL** — `/dca/crawl` accepts only one URL. |
+| **Multi-URL (`--urls` / `--input-file`)** | `/dca/trigger` (array body) → poll `/dca/dataset` | 2+ URLs through the same collector. One API call, one snapshot ID, one merged result array. Use the longer `--timeout` (default 3600s) for big batches. |
 
 ```bash
 # Default — async + poll (recommended for most cases)
@@ -151,6 +159,18 @@ bdata scraper run c_mp3tuab31lswoxvpws https://example.com/p/1 --sync
 # Sync with a tighter server timeout
 bdata scraper run c_mp3tuab31lswoxvpws https://example.com/p/1 \
     --sync --sync-timeout 30
+
+# Multi-URL via comma-separated list — one batch call
+bdata scraper run c_mp3tuab31lswoxvpws \
+    --urls "https://example.com/p/1,https://example.com/p/2,https://example.com/p/3" \
+    --pretty -o products.json
+
+# Multi-URL via file (one URL per line; # comments and blanks ignored)
+bdata scraper run c_mp3tuab31lswoxvpws --input-file urls.txt -o products.json
+
+# Multi-URL via JSON array
+echo '["https://example.com/p/1","https://example.com/p/2"]' > urls.json
+bdata scraper run c_mp3tuab31lswoxvpws --input-file urls.json
 ```
 
 ### `--sync-timeout` is bounded to 25–50
@@ -182,7 +202,7 @@ If the user only sees the notice and a long wait, that is expected — large job
 
 ## Full create-then-run workflow
 
-Capture the `collector_id` cleanly with `jq`, then chain into `run`:
+Capture the `collector_id` cleanly with `jq`, then chain into `run` with the multi-URL batch path:
 
 ```bash
 # 1. Create the scraper, save the AI output, extract the collector_id
@@ -194,13 +214,14 @@ bdata scraper create https://example.com/product/1 \
 COLLECTOR_ID=$(jq -r '.collector_id // .id' create.json)
 echo "Built: $COLLECTOR_ID"
 
-# 3. Run it on each URL you want extracted
-for url in $(cat urls.txt); do
-    bdata scraper run "$COLLECTOR_ID" "$url" --json -o "out/${url//[\/:.]/_}.json"
-done
+# 3. Run it on every URL in one batch — single API call, merged result array
+bdata scraper run "$COLLECTOR_ID" --input-file urls.txt \
+    --pretty -o out/results.json
 ```
 
-For more end-to-end recipes (batch run loops, error recovery, web-UI handoff), see [references/recipes.md](references/recipes.md).
+**Do not** wrap `bdata scraper run` in a `for url in $(cat urls.txt); do ... done` loop — that's N API calls and N snapshots. Use `--input-file urls.txt` (or `--urls "..."`) instead; the CLI POSTs all of them to `/dca/trigger` in a single array body and returns one merged result array.
+
+For more end-to-end recipes (batch input file shapes, error recovery, web-UI handoff), see [references/recipes.md](references/recipes.md).
 
 ---
 
@@ -219,6 +240,8 @@ For more end-to-end recipes (batch run loops, error recovery, web-UI handoff), s
 6. **Throwing away `collector_id` / `response_id` on error.** The CLI prints them in every failure path on purpose. Both are recoverable via the API and the web UI. Always surface them to the user.
 
 7. **Trying to disable the batch auto-fallback.** It has no flag. The fallback is the correct behavior when a URL expands past the realtime page limit. Let it run.
+
+8. **Hand-rolling a `for url in $(cat urls.txt); do bdata scraper run ...` loop.** That's N API calls, N snapshot IDs, and N poll loops for what the API natively treats as one batch. Use `--input-file urls.txt` or `--urls "u1,u2,..."` — the CLI posts the whole array to `/dca/trigger` in a single request and returns one merged result array. This mirrors the canonical `triggerWithUrls` / `trigger_with_urls` helpers from the Scraper Studio reference SDKs.
 
 8. **Vague descriptions in `create`.** A description like "scrape the page" produces a generic scraper. Name every field, name conditions ("if there's a sale price, capture both"), name disambiguators ("the price near the title, not in the recommendations sidebar"). See [references/prompts.md](references/prompts.md).
 

--- a/skills/scraper-studio/references/api-flow.md
+++ b/skills/scraper-studio/references/api-flow.md
@@ -108,9 +108,12 @@ Outcomes:
 - **202 + `{"error":"crawl_results_timeout","response_id":"r_late_..."}`** → server-side timeout. CLI prints the `response_id` and tells the user to **re-run without `--sync`**. The same request can be picked up async by polling `/dca/get_result?response_id=...` (which is what `bdata scraper run <collector_id> <url>` will do under the hood — though it triggers a new request, so for true reuse of the existing `response_id` you'd call `get_result` directly).
 - Other non-200 → surfaced as an error.
 
-### Path C — auto-fallback to batch
+### Path C — batch (`/dca/trigger`)
 
-Triggered when path A or B returns a body that contains the marker `realtime job limit` (case-insensitive). Typically looks like:
+The CLI takes this path in two situations:
+
+1. **Explicit multi-URL** — caller passes `--urls "u1,u2,..."` or `--input-file <path>` with 2+ URLs. The CLI skips paths A/B entirely and goes straight to `/dca/trigger` with an array body. This mirrors the canonical [`triggerWithUrls`](https://github.com/brightdata/bright-data-scraper-studio-nodejs-project) / [`trigger_with_urls`](https://github.com/brightdata/bright-data-scraper-studio-python-project) helpers from the Scraper Studio reference SDKs.
+2. **Auto-fallback from A or B** — single-URL path returned a body containing the marker `realtime job limit` (case-insensitive). Typically:
 
 ```json
 [{
@@ -119,12 +122,14 @@ Triggered when path A or B returns a body that contains the marker `realtime job
 }]
 ```
 
-The CLI then makes:
+In both cases the CLI then makes a single call:
 
 ```
 POST /dca/trigger?collector={collector_id}&name=...&version=...
 [
-  { "url": "https://example.com/listing" }   // body is an array
+  { "url": "https://example.com/p/1" },
+  { "url": "https://example.com/p/2" },
+  ...
 ]
 ```
 

--- a/skills/scraper-studio/references/recipes.md
+++ b/skills/scraper-studio/references/recipes.md
@@ -25,31 +25,39 @@ bdata scraper run "$COLLECTOR_ID" https://example.com/product/2 \
 jq 'keys' product-2.json
 ```
 
-## Recipe 2 — fan out one collector over many URLs
+## Recipe 2 — run one collector over many URLs (single batch call)
+
+Pass the URL list to `bdata scraper run` directly via `--input-file` or `--urls`. The CLI POSTs the entire array to `/dca/trigger` in one request — one snapshot, one poll loop, one merged result array. This is the canonical batch shape from the Scraper Studio reference SDKs (`triggerWithUrls` / `trigger_with_urls`).
 
 ```bash
-# Assume you already have a collector_id from a previous create
 COLLECTOR_ID="c_mp3tuab31lswoxvpws"
-mkdir -p out
 
-while IFS= read -r url; do
-    [ -z "$url" ] && continue
-    # Hash the URL so filenames are safe and unique
-    hash=$(printf '%s' "$url" | md5sum | cut -c1-8)
-    echo "[$hash] $url"
-    bdata scraper run "$COLLECTOR_ID" "$url" \
-        --json -o "out/${hash}.json" \
-        || echo "  ! failed: $url" >> out/failures.log
-done < urls.txt
+# One URL per line, # comments and blank lines ignored
+cat > urls.txt <<'EOF'
+https://example.com/p/1
+https://example.com/p/2
+# https://example.com/p/3   ← skipped
+https://example.com/p/4
+EOF
 
-echo "Done. $(ls out/*.json 2>/dev/null | wc -l) results, \
-$(wc -l < out/failures.log 2>/dev/null || echo 0) failures."
+bdata scraper run "$COLLECTOR_ID" --input-file urls.txt \
+    --pretty -o out/results.json
+
+# Or inline, comma-separated
+bdata scraper run "$COLLECTOR_ID" \
+    --urls "https://example.com/p/1,https://example.com/p/2,https://example.com/p/3" \
+    --pretty -o out/results.json
+
+# Or a JSON array — strings, or objects with a "url" field
+echo '["https://example.com/p/1","https://example.com/p/2"]' > urls.json
+bdata scraper run "$COLLECTOR_ID" --input-file urls.json -o out/results.json
 ```
 
 Notes:
-- Default async + poll mode (no `--sync`) is safest for batch.
-- Run sequentially unless you've confirmed your account's concurrent-job limit. Bright Data jobs are server-side; the CLI doesn't parallelize them for you.
-- For very large URL lists (100+), prefer the web UI's bulk input or the `/dca/trigger` batch endpoint directly — see [api-flow.md](api-flow.md).
+- Output is a single JSON array of N records, one per input URL. Aggregate downstream with `jq` if you need per-URL files.
+- The default batch timeout is **3600s** (1h). Raise `--timeout` for very large lists if a poll attempt runs over.
+- `--sync` is **incompatible** with multi-URL input — `/dca/crawl` accepts only one URL. Drop `--sync` for batch.
+- **Do not** wrap `scraper run` in a `for url in ...; do bdata scraper run ... done` shell loop — that's N API calls and N snapshots instead of one. Use the input flags.
 
 ## Recipe 3 — try sync, fall back to async on timeout
 


### PR DESCRIPTION
## Summary

Mirrors the CLI-side multi-URL change on `bdata scraper run` ([brightdata/cli#8](https://github.com/brightdata/cli/pull/8)). That PR adds `--urls` and `--input-file` so a list of URLs becomes one `/dca/trigger` call with an array body — the canonical pattern used by the Scraper Studio reference SDKs ([Node `triggerWithUrls`](https://github.com/brightdata/bright-data-scraper-studio-nodejs-project), [Python `trigger_with_urls`](https://github.com/brightdata/bright-data-scraper-studio-python-project)).

This PR updates the `scraper-studio` skill so an agent reading it picks the batch flags instead of hand-rolling a `for url in $(cat urls.txt); do bdata scraper run ...` loop (which would be N API calls and N snapshots for what is natively one call).

## Files touched

### `SKILL.md`
- **Frontmatter** — added the multi-URL triggers: `batch scrape`, `scrape these URLs`, `scrape a list of URLs`, `competitive pricing table`, `--urls`, `--input-file`. Description now mentions the multi-URL batch flow alongside the existing single-URL + sync flows.
- **"Pick your path" table** — added a row for "many URLs" pointing at `--urls` / `--input-file`.
- **Action 2 (`scraper run`)** — rewrote the synopsis (positional `[url]` optional, plus the two new flags), added a "pick exactly one input source" rule, and an explicit note that hand-rolled `for url in $(cat urls.txt); do scraper run ...` loops are the antipattern this replaces.
- **Run-mode table** — third row for the multi-URL path (`/dca/trigger` → poll `/dca/dataset`, longer default timeout).
- **Examples** — three new shell examples for `--urls` (comma list), `--input-file` (txt one-per-line), and `--input-file` (JSON array).
- **Common mistakes** — new item 8 calling out the loop antipattern and pointing at the batch flags.
- **"Full create-then-run workflow"** — replaced the for-loop with a single `--input-file` invocation.

### `references/recipes.md`
- **Recipe 2** "fan out one collector over many URLs" rewritten end to end. Old recipe was literally the hand-rolled loop the skill now warns against; new recipe shows `--input-file` (txt + JSON) and `--urls`. Notes call out the longer batch timeout, the `--sync` incompatibility, and the antipattern explicitly.

### `references/api-flow.md`
- **Path C** ("auto-fallback to batch") renamed to "batch (`/dca/trigger`)" and reframed as two entry points: explicit multi-URL (new) and the existing auto-fallback. Example body updated to show 2+ URLs.

## Dependency

This PR documents behavior introduced in [brightdata/cli#8](https://github.com/brightdata/cli/pull/8). It can land before or after that — the skill still steers agents correctly even on the older CLI (they'd see the rejection error and ask to upgrade), but pairing them is cleanest.

## Test plan

- [ ] Skill renders correctly in the marketplace UI (no broken links to references)
- [ ] Agent reading the skill with the new CLI picks `--input-file` for a "scrape this list of URLs" prompt
- [ ] Agent does NOT regenerate the old loop pattern when the user mentions "batch scrape" or "scrape a list of URLs"

🤖 Generated with [Claude Code](https://claude.com/claude-code)