### PR TITLE
docs(scraper-studio): document `scraper heal` self-healing

### DIFF
--- a/skills/scraper-studio/SKILL.md
+++ b/skills/scraper-studio/SKILL.md
@@ -33,7 +33,7 @@ Halt and route to setup if either check fails. Both commands require an authenti
 | User describes data they want from a URL, no scraper exists yet | `bdata scraper create <url> "<description>"` → save the `collector_id` |
 | User has a `collector_id` and wants data from a URL | `bdata scraper run <collector_id> <url>` (default async + poll) |
 | Page is small and you want fast feedback (≤ ~50 s) | `bdata scraper run … --sync` |
-| Scraper ran but returned wrong / empty / partial data | inspect the output, then `bdata scraper heal <collector_id> "<what's wrong>"` → re-run to verify |
+| Scraper ran but returned wrong / empty / partial data | inspect the output, then `bdata scraper heal <collector_id> "<what's wrong>"` → review preview → approve → re-run to verify |
 | Site is a known platform (Amazon, LinkedIn, TikTok, …) | **stop — use `data-feeds` skill** |
 | You want SERP / discovery, not extraction | **use `search` skill** |
 | You want a one-off raw page fetch | **use `scrape` skill** |
@@ -202,28 +202,69 @@ The `<prompt>` is required and is the most important input. Name exactly what is
 
 ### Output + the verify loop
 
-On success `heal` returns an envelope and, crucially, a `next_step` — a ready-to-run command to verify the fix:
+`heal` (without `--auto-approve`) usually ends at an **approval gate** rather
+than completing immediately. The response carries `status: "awaiting_approval"`
+with two key fields:
+
+- `preview_result` — sample rows the fixed scraper would produce, so you can
+  judge whether the fix is correct before committing it.
+- `diff_summary` — a summary of what changed in the template.
+- `next_step` — points at `bdata scraper approve <collector_id>` to commit
+  (or `--reject` to discard).
 
 ```json
 {
   "collector_id": "c_mp3tuab31lswoxvpws",
-  "status": "done",
-  "completed_steps": ["plan", "patch"],
-  "prompt": "Price returns null — selector moved …",
-  "view_url": "https://brightdata.com/cp/scrapers/c_mp3tuab31lswoxvpws",
-  "next_step": "bdata scraper run c_mp3tuab31lswoxvpws https://example.com/product/1"
+  "status": "awaiting_approval",
+  "preview_result": [{"price": "29.99", "currency": "USD"}],
+  "diff_summary": "Updated price selector from .price to span[data-testid='price']",
+  "next_step": "bdata scraper approve c_mp3tuab31lswoxvpws"
 }
 ```
 
-Pass `--url <verify-url>` so `next_step` is concrete. Then run it and re-inspect the data — that closes the self-healing loop:
+Review `preview_result`, then run `bdata scraper approve <collector_id>` to
+commit the fix — or pass `--reject` to discard it and re-heal with a sharper
+prompt. `approve` polls to `done` and hands back a `next_step` =
+`bdata scraper run <id> <url>` to verify.
+
+Pass `--url <verify-url>` to `heal` so the approve and run steps are concrete.
+The full self-healing loop is now:
 
 ```
-run → inspect → heal "<what's wrong>" → run again → verify
+run → inspect → heal → review preview → approve → run → verify
 ```
+
+To skip the gate entirely, use `heal --auto-approve` — it approves automatically
+and polls through to `done`.
 
 ### Failure is non-destructive
 
 If a heal fails (429 cap exhausted, timeout, terminal `failed`), the existing scraper is **unchanged and still works** as it did before. The CLI says so and prints the `collector_id`. Unlike a failed `create`, nothing half-built is left behind.
+
+---
+
+## Action 4 — `scraper approve`
+
+A `scraper heal` (without `--auto-approve`) stops at an approval gate:
+`status: "awaiting_approval"`, with `preview_result` (sample rows the fixed
+scraper would produce) and a `diff_summary`. Review the preview, then commit
+the fix:
+
+```bash
+bdata scraper approve <collector_id> [--reject] [--url <verify-url>] \
+    [--timeout <seconds>] [--json | --pretty] [-o <path>] [-k <api-key>]
+```
+
+- Approves by default (`POST /dca/collectors/{id}/resume_automation_job
+  {"message": true}`), then polls to `done` and hands back a
+  `next_step` = `bdata scraper run <id> <url>` to verify.
+- `--reject` sends `{"message": false}` to discard the proposed fix; re-heal
+  with a sharper prompt to try again.
+- If a heal needs multiple approvals, `approve` may stop at
+  `awaiting_approval` again — just run it again.
+
+`awaiting_approval` is **not** a failure — it means the fix is ready and
+waiting for your decision.
 
 ---
 
@@ -273,6 +314,11 @@ For more end-to-end recipes (batch run loops, error recovery, web-UI handoff), s
    collector and orphans the old one. To fix an existing scraper, use
    `bdata scraper heal <collector_id> "<what's wrong>"` — it mutates the
    scraper in place so your saved `collector_id` keeps working and improves.
+
+10. **Treating `awaiting_approval` as a failure.** It is the normal end state
+    of a heal — the fix is computed and waiting for your decision. Review
+    `preview_result`, then `bdata scraper approve <id>` (or `--reject`). Use
+    `heal --auto-approve` to skip the gate.
 
 ---
 

--- a/skills/scraper-studio/SKILL.md
+++ b/skills/scraper-studio/SKILL.md
@@ -33,6 +33,7 @@ Halt and route to setup if either check fails. Both commands require an authenti
 | User describes data they want from a URL, no scraper exists yet | `bdata scraper create <url> "<description>"` → save the `collector_id` |
 | User has a `collector_id` and wants data from a URL | `bdata scraper run <collector_id> <url>` (default async + poll) |
 | Page is small and you want fast feedback (≤ ~50 s) | `bdata scraper run … --sync` |
+| Scraper ran but returned wrong / empty / partial data | inspect the output, then `bdata scraper heal <collector_id> "<what's wrong>"` → re-run to verify |
 | Site is a known platform (Amazon, LinkedIn, TikTok, …) | **stop — use `data-feeds` skill** |
 | You want SERP / discovery, not extraction | **use `search` skill** |
 | You want a one-off raw page fetch | **use `scrape` skill** |
@@ -180,6 +181,52 @@ If the user only sees the notice and a long wait, that is expected — large job
 
 ---
 
+## Action 3 — `scraper heal`
+
+Fix an existing scraper **in place** when it ran but returned wrong, empty, or partial data. The scraper's `collector_id` stays the same — it is improved, not replaced.
+
+```bash
+bdata scraper heal <collector_id> "<what's wrong>" [--url <verify-url>] \
+    [--timeout <seconds>] [--max-retries <n>] [--no-retry] \
+    [--json | --pretty] [-o <path>] [--timing] [-k <api-key>]
+```
+
+**You are the detector.** The CLI never decides on its own that a scraper is broken — you inspect the run output and decide. A heal is slow and billable, so only heal when the data is actually wrong, not just legitimately empty.
+
+The `<prompt>` is required and is the most important input. Name exactly what is wrong and what the correct output should be: *"The price field returns null — the selector moved into a `<span data-testid=...>`. Capture price and currency again."* Vague prompts ("fix it") produce vague heals.
+
+### What happens under the hood
+
+1. **`POST /dca/collectors/{collector_id}/refactor_template`** with `{prompt, custom_input: []}` — triggers the AI self-healing job.
+2. **`GET .../refactor_template/progress`** (polled) — waits for `status: "done"`, same job shape and timing as `automate_template`.
+
+### Output + the verify loop
+
+On success `heal` returns an envelope and, crucially, a `next_step` — a ready-to-run command to verify the fix:
+
+```json
+{
+  "collector_id": "c_mp3tuab31lswoxvpws",
+  "status": "done",
+  "completed_steps": ["plan", "patch"],
+  "prompt": "Price returns null — selector moved …",
+  "view_url": "https://brightdata.com/cp/scrapers/c_mp3tuab31lswoxvpws",
+  "next_step": "bdata scraper run c_mp3tuab31lswoxvpws https://example.com/product/1"
+}
+```
+
+Pass `--url <verify-url>` so `next_step` is concrete. Then run it and re-inspect the data — that closes the self-healing loop:
+
+```
+run → inspect → heal "<what's wrong>" → run again → verify
+```
+
+### Failure is non-destructive
+
+If a heal fails (429 cap exhausted, timeout, terminal `failed`), the existing scraper is **unchanged and still works** as it did before. The CLI says so and prints the `collector_id`. Unlike a failed `create`, nothing half-built is left behind.
+
+---
+
 ## Full create-then-run workflow
 
 Capture the `collector_id` cleanly with `jq`, then chain into `run`:
@@ -221,6 +268,11 @@ For more end-to-end recipes (batch run loops, error recovery, web-UI handoff), s
 7. **Trying to disable the batch auto-fallback.** It has no flag. The fallback is the correct behavior when a URL expands past the realtime page limit. Let it run.
 
 8. **Vague descriptions in `create`.** A description like "scrape the page" produces a generic scraper. Name every field, name conditions ("if there's a sale price, capture both"), name disambiguators ("the price near the title, not in the recommendations sidebar"). See [references/prompts.md](references/prompts.md).
+
+9. **Re-running `create` to fix a broken scraper.** That builds a *new*
+   collector and orphans the old one. To fix an existing scraper, use
+   `bdata scraper heal <collector_id> "<what's wrong>"` — it mutates the
+   scraper in place so your saved `collector_id` keeps working and improves.
 
 ---
 

--- a/skills/scraper-studio/SKILL.md
+++ b/skills/scraper-studio/SKILL.md
@@ -193,7 +193,7 @@ bdata scraper heal <collector_id> "<what's wrong>" [--url <verify-url>] \
 
 **You are the detector.** The CLI never decides on its own that a scraper is broken — you inspect the run output and decide. A heal is slow and billable, so only heal when the data is actually wrong, not just legitimately empty.
 
-The `<prompt>` is required and is the most important input. Name exactly what is wrong and what the correct output should be: *"The price field returns null — the selector moved into a `<span data-testid=...>`. Capture price and currency again."* Vague prompts ("fix it") produce vague heals.
+The `<prompt>` is required and is the most important input. Name exactly what is wrong and what the correct output should be: *"The price field returns null — the selector moved into a `<span data-testid=...>`. Capture price and currency again."* Vague prompts ("fix it") produce vague heals. The prompt is capped at 1000 characters.
 
 ### What happens under the hood
 

--- a/skills/scraper-studio/references/api-flow.md
+++ b/skills/scraper-studio/references/api-flow.md
@@ -173,6 +173,21 @@ Returns the same job-progress shape as `automate_template/progress`
 timeout, or a terminal `failed` / `error` / `cancelled`. Default poll timeout
 600 s (`--timeout`).
 
+### 3. Approval gate + resume
+
+The self-healing flow pauses at `status: "pending_answer"` / `step:
+"user_approval"`, returning `diff` (before/after templates) and
+`preview_result` (sample output). It does **not** auto-advance. To commit (or
+discard) the fix:
+
+```
+POST /dca/collectors/{collector_id}/resume_automation_job
+{ "message": true }     // true = approve, false = reject
+```
+
+After resuming, `refactor_template/progress` continues to `done`. `scraper
+approve` wraps this; `scraper heal --auto-approve` calls it automatically.
+
 **Recoverability:** if the heal fails, the collector is unchanged and still
 works — nothing is left half-built (unlike a failed `create`).
 

--- a/skills/scraper-studio/references/api-flow.md
+++ b/skills/scraper-studio/references/api-flow.md
@@ -148,6 +148,36 @@ Batch defaults: 10 s poll interval, 3600 s (1 hour) timeout.
 
 ---
 
+## `scraper heal` — trigger + poll
+
+Maintenance twin of `create`'s AI flow, against an existing collector.
+
+### 1. Trigger self-healing
+
+```
+POST /dca/collectors/{collector_id}/refactor_template
+{
+  "prompt": "Price returns null — selector moved …",
+  "custom_input": []
+}
+```
+
+### 2. Poll progress
+
+```
+GET /dca/collectors/{collector_id}/refactor_template/progress
+```
+
+Returns the same job-progress shape as `automate_template/progress`
+(`{status, completed_steps, step}`); the CLI polls until `status: "done"`,
+timeout, or a terminal `failed` / `error` / `cancelled`. Default poll timeout
+600 s (`--timeout`).
+
+**Recoverability:** if the heal fails, the collector is unchanged and still
+works — nothing is left half-built (unlike a failed `create`).
+
+---
+
 ## Two artefacts, two failure recoveries
 
 | Artefact | Printed by | Used to recover via | Persists if step fails |

--- a/skills/scraper-studio/references/recipes.md
+++ b/skills/scraper-studio/references/recipes.md
@@ -124,3 +124,32 @@ bdata scraper run "$COLLECTOR_ID" https://example.com/page \
 ```
 
 `--name` tags the run so you can find it later in the dashboard's run history.
+
+## Recipe 7 — self-healing loop (run → inspect → heal → re-run)
+
+The agent is the detector: run, inspect the data, and only heal if it is
+actually wrong.
+
+```bash
+COLLECTOR_ID="c_mp3tuab31lswoxvpws"
+URL="https://example.com/product/1"
+
+# 1. Run and capture the data
+bdata scraper run "$COLLECTOR_ID" "$URL" --json -o out.json
+
+# 2. Inspect. If (and only if) the data is wrong — e.g. price is null when the
+#    page clearly shows a price — heal with a SPECIFIC prompt:
+if [ "$(jq -r '.price // "null"' out.json)" = "null" ]; then
+    bdata scraper heal "$COLLECTOR_ID" \
+        "The price field returns null — the selector moved into a span with \
+         data-testid. Capture price and currency again." \
+        --url "$URL" --pretty -o heal.json
+
+    # 3. heal.json.next_step is a ready-to-run verify command:
+    eval "$(jq -r '.next_step' heal.json) --json -o out.json"
+    jq '{price, currency}' out.json   # 4. verify the fix
+fi
+```
+
+Do **not** re-run `bdata scraper create` to fix a scraper — that orphans a new
+collector. `heal` fixes the existing one in place.

--- a/skills/scraper-studio/references/recipes.md
+++ b/skills/scraper-studio/references/recipes.md
@@ -125,31 +125,33 @@ bdata scraper run "$COLLECTOR_ID" https://example.com/page \
 
 `--name` tags the run so you can find it later in the dashboard's run history.
 
-## Recipe 7 — self-healing loop (run → inspect → heal → re-run)
+## Recipe 7 — self-healing loop (run → inspect → heal → approve → re-run)
 
-The agent is the detector: run, inspect the data, and only heal if it is
-actually wrong.
+The agent is the detector AND the approver: run, inspect, heal, review the
+preview, approve, re-run.
 
 ```bash
 COLLECTOR_ID="c_mp3tuab31lswoxvpws"
 URL="https://example.com/product/1"
 
-# 1. Run and capture the data
+# 1. Run and inspect
 bdata scraper run "$COLLECTOR_ID" "$URL" --json -o out.json
 
-# 2. Inspect. If (and only if) the data is wrong — e.g. price is null when the
-#    page clearly shows a price — heal with a SPECIFIC prompt:
-if [ "$(jq -r '.price // "null"' out.json)" = "null" ]; then
-    bdata scraper heal "$COLLECTOR_ID" \
-        "The price field returns null — the selector moved into a span with \
-         data-testid. Capture price and currency again." \
-        --url "$URL" --pretty -o heal.json
+# 2. If the data is wrong, heal (stops at the approval gate)
+bdata scraper heal "$COLLECTOR_ID" \
+    "Price returns null — the selector moved; capture price + currency." \
+    --url "$URL" --pretty -o heal.json
+# heal.json: status=awaiting_approval, preview_result shows the fix
 
-    # 3. heal.json.next_step is a ready-to-run verify command:
-    eval "$(jq -r '.next_step' heal.json) --json -o out.json"
-    jq '{price, currency}' out.json   # 4. verify the fix
+# 3. Review preview_result, then approve (or --reject)
+if [ "$(jq -r '.status' heal.json)" = "awaiting_approval" ]; then
+    bdata scraper approve "$COLLECTOR_ID" --url "$URL" --pretty -o approve.json
 fi
+
+# 4. Verify the committed fix
+eval "$(jq -r '.next_step' approve.json) --json -o out.json"
+jq '{price, currency}' out.json
 ```
 
-Do **not** re-run `bdata scraper create` to fix a scraper — that orphans a new
-collector. `heal` fixes the existing one in place.
+For a fully autonomous fix (no review), use `bdata scraper heal …
+--auto-approve`.


### PR DESCRIPTION
## Summary

Teaches coding agents the new `bdata scraper heal` command (companion to brightdata/cli#11). The `scraper-studio` skill is the interface agents read, so the feature is only usable once the skill documents it.

- **SKILL.md** — new "Action 3 — `scraper heal`" section (when to reach for it, required `<prompt>` ≤1000 chars, the `refactor_template` endpoints, the success envelope + `next_step` verify hint, non-destructive failure); a "Pick your path" row routing wrong/empty/partial results to heal; and a "Common mistakes" entry: don't re-run `create` to fix a scraper (it orphans a new collector) — `heal` fixes it in place.
- **references/api-flow.md** — the `refactor_template` trigger + `refactor_template/progress` poll documented in the same style as `automate_template`.
- **references/recipes.md** — Recipe 7: the full run → inspect → heal → re-run self-healing loop as a copy-paste shell snippet.

Framing throughout: the **agent is the detector** (CLI never auto-decides breakage), `run` stays read-only, heal mutates in place.

## Test Plan

- [x] `grep` confirms heal content in the path table, Action 3, and mistakes list (SKILL.md), the `refactor_template` endpoints (api-flow.md), and the self-healing loop recipe (recipes.md)
- [x] Code fences balanced; Action 3 sits between Action 2 and "Full create-then-run workflow"
- [x] Endpoints, request body `{prompt, custom_input: []}`, and non-destructive-failure framing are consistent across all three files and match the CLI implementation
- [ ] Reviewer skim for voice/accuracy