### PR TITLE
adding skills for specific flows

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -12,7 +12,7 @@
     {
       "name": "brightdata-plugin",
       "source": "./",
-      "description": "Web scraping, Google search, structured data extraction, and MCP server integration powered by Bright Data. Includes 15 skills: scrape any webpage as markdown (with bot detection/CAPTCHA bypass), search Google with structured JSON results, extract data from 40+ websites (Amazon, LinkedIn, Instagram, TikTok, YouTube, and more), orchestrate Bright Data's 60+ MCP tools, Bright Data CLI for terminal-based scraping/search/data extraction/zone management, real-time competitive intelligence (competitor snapshots, pricing comparison, review mining, hiring signals, market landscape mapping), built-in best practices for Web Unlocker, SERP API, Web Scraper API, and Browser API, proxy integration code for Datacenter/ISP/Residential/Mobile networks, Python SDK best practices for the brightdata-sdk package, scraper builder for any website, AI-generated Scraper Studio scrapers (`bdata scraper create` / `bdata scraper run`), SEO audits with live web data, agent onboarding, design system mirroring, and Browser API session debugging.",
+      "description": "Web scraping, Google search, structured data extraction, and MCP server integration powered by Bright Data. Includes 17 skills: scrape any webpage as markdown (with bot detection/CAPTCHA bypass), search Google with structured JSON results, extract data from 40+ websites (Amazon, LinkedIn, Instagram, TikTok, YouTube, and more), orchestrate Bright Data's 60+ MCP tools, Bright Data CLI for terminal-based scraping/search/data extraction/zone management, real-time competitive intelligence (competitor snapshots, pricing comparison, review mining, hiring signals, market landscape mapping), built-in best practices for Web Unlocker, SERP API, Web Scraper API, and Browser API, proxy integration code for Datacenter/ISP/Residential/Mobile networks, Python SDK best practices for the brightdata-sdk package, scraper builder for any website, AI-generated Scraper Studio scrapers (`bdata scraper create` / `bdata scraper run`), SEO audits with live web data, social listening and brand reputation monitoring (sentiment and themes across Reddit/X/Instagram/TikTok/YouTube/reviews), shopping price comparison across Amazon/Walmart/eBay/Best Buy/Google Shopping (find the cheapest in-stock offer, region-aware), agent onboarding, design system mirroring, and Browser API session debugging.",
       "version": "1.6.3",
       "author": {
         "name": "Bright Data",
@@ -54,7 +54,15 @@
         "competitive-intelligence",
         "market-research",
         "competitor-analysis",
-        "pricing-intelligence"
+        "pricing-intelligence",
+        "social-listening",
+        "brand-monitoring",
+        "sentiment-analysis",
+        "brand-research",
+        "price-comparison",
+        "shopping",
+        "deal-finder",
+        "price-tracking"
       ],
       "category": "web-integration",
       "tags": [
@@ -69,7 +77,11 @@
         "python-sdk",
         "cli",
         "competitive-intelligence",
-        "market-research"
+        "market-research",
+        "social-listening",
+        "brand-monitoring",
+        "price-comparison",
+        "shopping"
       ]
     }
   ]

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "brightdata-plugin",
-  "description": "Web scraping, Google search, structured data extraction, and MCP server integration powered by Bright Data. Includes 15 skills: scrape any webpage as markdown (with bot detection/CAPTCHA bypass), search Google with structured JSON results, extract data from 40+ websites (Amazon, LinkedIn, Instagram, TikTok, YouTube, and more), orchestrate Bright Data's 60+ MCP tools, Bright Data CLI for terminal-based scraping/search/data extraction/zone management, real-time competitive intelligence (competitor snapshots, pricing comparison, review mining, hiring signals, market landscape mapping), built-in best practices for Web Unlocker, SERP API, Web Scraper API, and Browser API, proxy integration code for Datacenter/ISP/Residential/Mobile networks, Python SDK best practices for the brightdata-sdk package, scraper builder for any website, AI-generated Scraper Studio scrapers (`bdata scraper create` / `bdata scraper run`), SEO audits with live web data, agent onboarding, design system mirroring, and Browser API session debugging.",
+  "description": "Web scraping, Google search, structured data extraction, and MCP server integration powered by Bright Data. Includes 17 skills: scrape any webpage as markdown (with bot detection/CAPTCHA bypass), search Google with structured JSON results, extract data from 40+ websites (Amazon, LinkedIn, Instagram, TikTok, YouTube, and more), orchestrate Bright Data's 60+ MCP tools, Bright Data CLI for terminal-based scraping/search/data extraction/zone management, real-time competitive intelligence (competitor snapshots, pricing comparison, review mining, hiring signals, market landscape mapping), built-in best practices for Web Unlocker, SERP API, Web Scraper API, and Browser API, proxy integration code for Datacenter/ISP/Residential/Mobile networks, Python SDK best practices for the brightdata-sdk package, scraper builder for any website, AI-generated Scraper Studio scrapers (`bdata scraper create` / `bdata scraper run`), SEO audits with live web data, social listening and brand reputation monitoring (sentiment and themes across Reddit/X/Instagram/TikTok/YouTube/reviews), shopping price comparison across Amazon/Walmart/eBay/Best Buy/Google Shopping (find the cheapest in-stock offer, region-aware), agent onboarding, design system mirroring, and Browser API session debugging.",
   "version": "1.6.3",
   "author": {
     "name": "Bright Data",
@@ -43,6 +43,14 @@
     "competitive-intelligence",
     "market-research",
     "competitor-analysis",
-    "pricing-intelligence"
+    "pricing-intelligence",
+    "social-listening",
+    "brand-monitoring",
+    "sentiment-analysis",
+    "brand-research",
+    "price-comparison",
+    "shopping",
+    "deal-finder",
+    "price-tracking"
   ]
 }

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 <p align="center">
   <a href="https://brightdata.com"><img src="https://img.shields.io/badge/Powered%20by-Bright%20Data-3D7FFC?style=for-the-badge" alt="Powered by Bright Data"></a>
   <a href="#license"><img src="https://img.shields.io/badge/License-MIT-10b981?style=for-the-badge" alt="MIT License"></a>
-  <a href="#skills"><img src="https://img.shields.io/badge/Skills-15-9D97F4?style=for-the-badge" alt="15 Skills"></a>
+  <a href="#skills"><img src="https://img.shields.io/badge/Skills-17-9D97F4?style=for-the-badge" alt="17 Skills"></a>
   <a href="#data-feeds-skill"><img src="https://img.shields.io/badge/Datasets-40+-15C1E6?style=for-the-badge" alt="40+ Datasets"></a>
   <a href="#bright-data-mcp-skill"><img src="https://img.shields.io/badge/MCP_Tools-60+-FF6B35?style=for-the-badge" alt="60+ MCP Tools"></a>
 </p>
@@ -69,6 +69,8 @@ Built on Bright Data's [Web Unlocker](https://brightdata.com/products/web-unlock
 | **`python-sdk-best-practices`** | Comprehensive guide for the `brightdata-sdk` Python package — async/sync clients, platform scrapers, SERP, datasets, Scraper Studio, Browser API, error handling, and common patterns |
 | **`brightdata-cli`** | Guide for using the Bright Data CLI (`brightdata` / `bdata`) to scrape, search, extract structured data from 40+ platforms, manage proxy zones, and check account budget — all from the terminal |
 | **`competitive-intel`** | Real-time competitive intelligence using live web data — competitor snapshots, pricing comparison, review mining, hiring signal analysis, content & SEO battles, and market landscape mapping. Replaces $15K+/yr enterprise CI tools at pennies per analysis |
+| **`brand-listening`** | Social listening and brand reputation research — collects what people are saying about a brand across Reddit, X, Instagram, TikTok, YouTube, news, and review sites, then classifies sentiment, clusters themes, and delivers a cited digest with recommendations. Triggers on "what are people saying about us", "monitor mentions", "brand sentiment" |
+| **`price-comparison`** | Shopping price comparison using live retailer data — resolves a product (name, ASIN, or URL) across Amazon, Walmart, eBay, Best Buy, and Google Shopping, normalizes prices/availability/condition into one ranked table, and names the cheapest in-stock buy. Region-aware (currency, stock, local retailers). Triggers on "compare prices", "find the cheapest", "price check", "how much is X on Amazon vs Walmart" |
 | **`seo-audit`** | Comprehensive SEO audit using live web data — sitemap-stratified sampling, JS-injected schema detection (Yoast/RankMath/AIOSEO), hreflang validation, signal-driven SERP ranking checks, HTML-level Core Web Vitals proxies. Auto-routes between single-page and site-wide audits |
 | **`design-mirror`** | Replicates design system patterns, tokens, and components to build consistent, high-quality UIs |
 | **`brd-browser-debug`** | Debug Bright Data Scraping Browser sessions — smart triage of failures, per-session bandwidth tracking, captcha reporting, and pattern detection using the Browser Sessions API |

--- a/skills/brand-listening/SKILL.md
+++ b/skills/brand-listening/SKILL.md
@@ -1,0 +1,155 @@
+---
+name: brand-listening
+description: >
+  Social listening and brand reputation research using Bright Data's web
+  scraping infrastructure. Collects what real people are saying about a brand,
+  product, or person across Reddit, X/Twitter, Instagram, TikTok, YouTube,
+  news, and review sites — then classifies sentiment, clusters themes, and
+  delivers a cited digest with actionable recommendations. Use this skill when
+  the user wants to know what people are saying about their brand, monitor
+  social media mentions, gauge public sentiment, track online reputation,
+  find complaints or advocacy, measure buzz around a launch, or do social
+  listening / brand monitoring / sentiment analysis. Also use when the user
+  mentions brand mentions, brand health, reputation tracking, or "what's the
+  internet saying about us".
+---
+
+# Brand Listening
+
+Find out what people are *actually* saying about a brand across social platforms, news, and reviews — powered by live web data, not stale training knowledge. Combines the Bright Data CLI (`bdata`) for collection with a sentiment + theme analysis layer to deliver a cited, actionable digest.
+
+**Never answer brand-sentiment questions from training knowledge alone.** Public sentiment changes daily. Always collect live mentions first, then classify and synthesize.
+
+## Prerequisites
+
+1. Bright Data CLI installed:
+   ```bash
+   curl -fsSL https://cli.brightdata.com/install.sh | bash
+   ```
+2. One-time login completed:
+   ```bash
+   bdata login    # or: bdata login --device  (SSH / headless)
+   ```
+
+Verify before collecting:
+```bash
+if ! command -v bdata >/dev/null 2>&1; then
+    echo "bdata CLI not installed — see skills/bright-data-best-practices/references/cli-setup.md"
+elif ! bdata zones >/dev/null 2>&1; then
+    echo "bdata not authenticated — run: bdata login"
+fi
+```
+
+Halt and route to setup if either check fails.
+
+## Core Workflow
+
+1. **Clarify scope** — Which brand/product/person? Which platforms? What time window (default: last 30 days)? What does the user want to *do* with it (general health check, launch monitoring, complaint triage, advocacy hunting)?
+2. **Discover, then collect** — Use `bdata search` to find where the brand is being discussed, then `bdata pipelines` to pull structured mentions from each platform. Parallelize independent calls.
+3. **Normalize** — Collapse every raw result into the single mention schema in [references/sentiment-and-output.md](references/sentiment-and-output.md) before any analysis.
+4. **Classify & cluster** — Assign sentiment per mention (with a reason), then group mentions into themes. Follow the sentiment guardrails — never inflate either side.
+5. **Deliver** — Produce the cited digest (Output A), optionally with the structured dataset (Output B). Every report ends with a "So what — recommendations" section.
+
+## Data Collection Rules
+
+- **Discovery first.** You rarely have the right URLs up front. Run `bdata search "<brand> site:reddit.com" --json` (and per-platform variants) to find threads, profiles, and articles, *then* feed those URLs to pipelines.
+- **Prefer `bdata pipelines`** over `bdata scrape` whenever a pipeline exists for the platform — pipelines return clean structured JSON (author, date, engagement, text).
+- **Always pass `--json`** when you need to parse or pipe output.
+- **Be cost-efficient** — a standard sweep is ~6–12 `bdata` calls, not 50. Pull the highest-signal threads/profiles, not everything.
+- **Parallelize** independent calls across multiple Bash tool calls in one response.
+- **Every mention needs a source URL.** No unattributed quotes, ever.
+- **Never fabricate sentiment or fill gaps.** If a platform returns nothing, report it in "Gaps & caveats".
+
+## Platform Modules
+
+Pick the platforms that fit the brand. Consumer/cultural brands skew TikTok/Instagram/Reddit; B2B/SaaS skews Reddit/X/review sites; local businesses skew Google Maps reviews.
+
+### Reddit — honest, unfiltered sentiment
+```bash
+# Discover relevant threads
+bdata search "<brand> site:reddit.com" --json
+bdata search "<brand> review reddit" --json
+
+# Pull structured post + comment data from the threads found
+bdata pipelines reddit_posts "<reddit-thread-url>" --json -o reddit.json
+```
+Reddit is the single best source for candid opinions brand channels hide. Prioritize it.
+
+### X / Twitter — real-time reaction
+```bash
+bdata search "<brand>" --json                      # find recent discussion
+bdata pipelines x_posts "<x-profile-or-post-url>" --json -o x.json
+```
+
+### Instagram — brand aesthetics, comments, advocacy
+```bash
+bdata pipelines instagram_posts "https://www.instagram.com/<brand>/" --json -o ig_posts.json
+bdata pipelines instagram_comments "<instagram-post-url>" --json -o ig_comments.json
+```
+
+### TikTok — cultural relevance, viral sentiment
+```bash
+bdata pipelines tiktok_posts "https://www.tiktok.com/@<brand>" --json -o tt_posts.json
+bdata pipelines tiktok_comments "<tiktok-video-url>" --json -o tt_comments.json
+```
+
+### YouTube — reviews, tutorials, long-form opinion (comments are gold)
+```bash
+bdata search "<brand> review youtube" --json
+bdata pipelines youtube_videos "<video-url>" --json -o yt_videos.json
+bdata pipelines youtube_comments "<video-url>" 100 --json -o yt_comments.json   # url + num_comments
+```
+
+### Reviews — structured customer sentiment
+```bash
+# App-based products
+bdata pipelines google_play_store "<play-store-url>" --json -o play.json
+bdata pipelines apple_app_store "<app-store-url>" --json -o appstore.json
+
+# Local / physical businesses
+bdata pipelines google_maps_reviews "<maps-url>" 90 --json -o gmaps.json   # url + days_limit
+
+# Facebook page reviews
+bdata pipelines facebook_company_reviews "<fb-page-url>" 50 --json -o fb_reviews.json   # url + num
+
+# SaaS / software — discover then scrape (no pipeline)
+bdata search "<brand> site:g2.com" --json
+bdata search "<brand> site:capterra.com" --json
+bdata scrape "<g2-or-capterra-url>"
+```
+
+### News & press — coverage and tone
+```bash
+bdata search "<brand>" --json                  # general SERP, scan for news
+bdata scrape "<article-url>"                    # pull full article text for tone
+```
+
+> **Pipeline names change.** Always confirm with `bdata pipelines list` before hardcoding a type. Names are inconsistent across platforms (`tiktok_posts` plural, `reddit_posts` plural, `x_posts`). The `data-feeds` skill has the verified list.
+
+## Choosing What to Collect
+
+| User says... | Collect from |
+|---|---|
+| "What are people saying about us / my brand" | Reddit + X + reviews + news (broad sweep) |
+| "How did our launch land" / "buzz around X" | TikTok + Instagram + X + YouTube (recency-focused) |
+| "Find complaints / what people hate" | Reddit + reviews (G2/Capterra/app stores) + YouTube comments |
+| "Who's advocating for us / fans" | Instagram + TikTok + X (high-engagement positive posts) |
+| "Reputation / sentiment over time" | Same sources, two windows — compare prior vs current |
+| Local business reputation | Google Maps reviews + Facebook reviews |
+
+## Sentiment, Themes & Output
+
+Read [references/sentiment-and-output.md](references/sentiment-and-output.md) for:
+- The **normalized mention record** schema (use it as the row shape for both analysis and the dataset output).
+- The **sentiment method + guardrails** (classify from text as written; sarcasm/ambiguous → `mixed`; always report counts *and* percentages with the denominator).
+- **Theme clustering** — where the actionable insight lives.
+- **Output templates** — A (digest report), B (structured dataset), C (both).
+
+## Output Quality Standards
+
+1. **Every mention has a source URL** — no unattributed claims.
+2. **Facts separate from interpretation** — the quote is the fact; your sentiment label is interpretation. Keep them distinct.
+3. **Percentages always carry N** — "61% positive of 142 classified mentions", never a bare percentage.
+4. **Be honest about gaps** — list platforms that returned nothing this window. Note small samples that can't generalize.
+5. **Date-stamp everything** — "Data collected on <date> · window: last <N> days".
+6. **End with "So what"** — every report closes with 2–4 actionable recommendations, each grounded in a theme from the data. Raw mentions without interpretation are not a deliverable.

--- a/skills/brand-listening/references/sentiment-and-output.md
+++ b/skills/brand-listening/references/sentiment-and-output.md
@@ -1,0 +1,104 @@
+# Sentiment, themes & output formats
+
+## Normalized mention record
+
+Collapse every raw result into this schema before analysis. This is also the row
+shape for the structured-dataset output.
+
+| Field | Notes |
+|---|---|
+| `platform` | reddit / x / instagram / tiktok / youtube / review / news |
+| `date` | ISO date of the mention |
+| `author` | handle or display name (or "n/a") |
+| `text` | the mention content (trim to the relevant part) |
+| `url` | direct link to the mention — **required**, never blank |
+| `engagement` | likes/upvotes/comments/views if available |
+| `sentiment` | positive / neutral / negative / mixed |
+| `sentiment_reason` | one short clause explaining the call |
+| `themes` | 1–3 tags (pricing, support, quality, UX, shipping, feature:X) |
+
+## Sentiment method (and guardrails)
+
+- Classify from the **text as written**, in context. A 5-star phrasing with "but…"
+  is usually `mixed`, not `positive`.
+- Mark sarcasm and ambiguous posts `mixed` rather than guessing — don't inflate either
+  side. Note when a platform's sample is too small to generalize.
+- Report sentiment as counts **and** percentages, with the denominator (e.g. "61%
+  positive of 142 classified mentions"). Never present a percentage without N.
+- Keep facts (the quote) separate from interpretation (your label).
+
+## Theme clustering
+
+Group mentions by recurring topic. For each theme: count, dominant sentiment, and 1–2
+representative cited quotes. Themes are where the actionable insight lives — they tell
+the user *why* people feel how they do.
+
+---
+
+## Output A — Digest report template
+
+```markdown
+# Brand Listening: <brand>
+*Data collected on <date> · window: last <N> days · platforms: <list>*
+
+## Snapshot
+- Total mentions: <N> across <platforms>
+- Sentiment: <P>% positive · <Q>% neutral · <R>% negative · <S>% mixed  (N classified)
+- Volume by platform: reddit <n>, x <n>, youtube <n>, ...
+- Net trend vs prior window: <up/down/flat, if comparable>
+
+## What's driving sentiment (themes)
+| Theme | Mentions | Dominant sentiment | Representative quote (cited) |
+|---|---|---|---|
+| Pricing | 22 | negative | "…too expensive for what you get" — [r/x](url), <date> |
+| Support | 14 | positive | "…support fixed it in an hour" — [@user](url), <date> |
+
+## Notable mentions
+- **[High reach]** "<quote>" — <author>, <platform>, <date>. [link](url)
+- **[Complaint]** "<quote>" — ... [link](url)
+- **[Advocacy]** "<quote>" — ... [link](url)
+
+## Gaps & caveats
+- Platforms with no mentions found this window: <list>
+- Anything that couldn't be measured / needed escalation.
+
+## So what — recommendations
+- <Actionable takeaway tied to a theme, e.g. "Pricing objection is the #1 negative
+  driver — address with a value comparison on the pricing page.">
+- <2–4 total, each grounded in the data above.>
+```
+
+Every report **must** end with the "So what" section. Raw data without interpretation
+is not a deliverable.
+
+## Output B — Structured dataset
+
+One row per normalized mention.
+
+```bash
+# Pipelines can emit CSV directly:
+bdata pipelines reddit_posts "<url>" --format csv -o reddit_mentions.csv
+# Then merge platform files and add sentiment/themes columns during normalization.
+```
+
+JSON shape:
+```json
+[
+  {
+    "platform": "reddit",
+    "date": "2026-05-28",
+    "author": "u/example",
+    "text": "switched to <brand> and support has been great",
+    "url": "https://reddit.com/r/.../comments/...",
+    "engagement": {"upvotes": 42, "comments": 7},
+    "sentiment": "positive",
+    "sentiment_reason": "praises support responsiveness",
+    "themes": ["support"]
+  }
+]
+```
+
+## Output C — Both
+
+Deliver the dataset (B) as the evidence layer and the digest (A) built on top, with
+the digest's quotes linking back to rows in the dataset.

--- a/skills/price-comparison/SKILL.md
+++ b/skills/price-comparison/SKILL.md
@@ -1,0 +1,177 @@
+---
+name: price-comparison
+description: >
+  Shopping price comparison using Bright Data's web scraping infrastructure.
+  Finds where a product is sold, for how much, and whether it's in stock —
+  across Amazon, Walmart, eBay, Best Buy, Google Shopping, and any retailer
+  URL — then ranks the offers into a single buy-recommendation table. Use this
+  skill when the user wants to compare prices, find the cheapest place to buy
+  something, do a price check, see "how much does X cost on Amazon vs Walmart",
+  track an item's price, or decide where to buy a product. Handles product
+  names, ASINs, and direct URLs, and is region-aware (country affects price,
+  availability, and which retailers apply). This is consumer purchase-decision
+  research — for analyzing a competitor's pricing *strategy*, use
+  competitive-intel instead.
+---
+
+# Price Comparison
+
+Find the best place to actually buy a product — lowest price, in stock, from a
+reputable seller — using live retailer data, not stale training knowledge.
+Combines the Bright Data CLI (`bdata`) for collection with a normalization +
+ranking layer to deliver a single cited comparison table and a clear buy
+recommendation.
+
+**Never quote prices from training knowledge.** Prices and stock change hourly.
+Always pull live data first, then compare. If a source fails, say so — never
+fill a price gap with a guess.
+
+## Prerequisites
+
+1. Bright Data CLI installed:
+   ```bash
+   curl -fsSL https://cli.brightdata.com/install.sh | bash
+   ```
+2. One-time login completed:
+   ```bash
+   bdata login    # or: bdata login --device  (SSH / headless)
+   ```
+
+Verify before collecting:
+```bash
+if ! command -v bdata >/dev/null 2>&1; then
+    echo "bdata CLI not installed — see skills/bright-data-best-practices/references/cli-setup.md"
+elif ! bdata zones >/dev/null 2>&1; then
+    echo "bdata not authenticated — run: bdata login"
+fi
+```
+
+Halt and route to setup if either check fails.
+
+## Core Workflow
+
+1. **Clarify scope** — *What* product (name, ASIN, or URL)? *Which* retailers
+   (default: Amazon + Google Shopping)? *Which* country/region (default: US —
+   it changes price, currency, availability, and which retailers apply)? What
+   matters beyond price (reviews, shipping/Prime, new vs refurbished)?
+2. **Resolve, then collect** — If you only have a product name, use
+   `amazon_product_search` and `bdata search --type shopping` to resolve it to
+   concrete product URLs/offers, *then* pull each retailer's structured data.
+   Parallelize independent calls.
+3. **Normalize** — Collapse every result into the single offer schema in
+   [references/output-and-pricing.md](references/output-and-pricing.md) before
+   comparing. Convert all prices to one currency and note the rate + date used.
+4. **Rank & flag** — Sort by total landed cost (price + shipping). Flag
+   out-of-stock, refurbished/used, and third-party-seller offers — a lower
+   price that's unavailable or used is not the winner by default.
+5. **Deliver** — Produce the comparison table (Output A), then the explicit
+   "Best buy" recommendation. Every report names the cheapest *in-stock* option
+   and any meaningful trade-offs.
+
+## Data Collection Rules
+
+- **Resolve names to URLs first.** You rarely have clean URLs up front. Use
+  `amazon_product_search "<query>" "https://www.amazon.com"` and
+  `bdata search "<product>" --type shopping --json` to find the exact items,
+  *then* feed those URLs to product pipelines.
+- **Prefer pipelines over scraping for supported retailers.** Amazon, Walmart,
+  eBay, Best Buy, Google Shopping all have structured pipelines that return
+  clean price/availability/rating JSON. Never `bdata scrape amazon.com` — Amazon
+  blocks scrapers; the pipeline bypasses that reliably.
+- **Always pass `--json`** when you need to parse or compare output.
+- **Be cost-efficient** — a standard comparison is ~3–8 `bdata` calls, not 50.
+  Pull the offers the user asked about, not every seller on the page.
+- **Parallelize** independent calls across multiple Bash tool calls in one
+  response — don't wait for Amazon before starting Walmart.
+- **Every price needs a source URL and a collection timestamp.** No
+  unattributed or undated prices, ever.
+- **Never fabricate a price or fill gaps.** If a retailer returns nothing,
+  report it in "Gaps & caveats".
+
+## Retailer Modules
+
+Pick the retailers that fit the product and region. US electronics → Amazon +
+Best Buy + Walmart + Google Shopping; marketplace/used → eBay; non-US → confirm
+the local Amazon domain and add region-relevant retailers.
+
+### Amazon — by URL or ASIN
+```bash
+bdata pipelines amazon_product "https://www.amazon.com/dp/<ASIN>" --json -o amazon.json
+```
+Returns price, `final_price`, title, availability, rating, review count, ASIN,
+seller, images. Use the right domain for the region (`amazon.com`, `amazon.de`,
+`amazon.co.uk`, …).
+
+### Amazon — discover by keyword (when you only have a name)
+```bash
+bdata pipelines amazon_product_search "iPhone 17 Pro 256GB" "https://www.amazon.com" --json -o amzn_search.json
+```
+Resolve the right ASIN/URL from the results, then call `amazon_product` on it.
+
+### Walmart / eBay / Best Buy — by product URL
+```bash
+bdata pipelines walmart_product "https://www.walmart.com/ip/<ID>" --json -o walmart.json
+bdata pipelines ebay_product     "https://www.ebay.com/itm/<ID>"   --json -o ebay.json
+bdata pipelines bestbuy_products "https://www.bestbuy.com/site/<ID>.p" --json -o bestbuy.json
+```
+
+### Google Shopping — cross-retailer overview
+```bash
+bdata pipelines google_shopping "<google-shopping-product-url>" --json -o gshopping.json
+```
+Best for a fast multi-seller view once you have a Shopping product URL. To
+*find* that URL (and a quick price spread) from a name, use SERP shopping:
+```bash
+bdata search "iPhone 17 Pro 256GB" --type shopping --country us --json
+```
+
+### Unknown / local retailer — scrape the page
+```bash
+bdata scrape "https://retailer.example/product-page"
+```
+Then extract price, currency, and stock from the markdown. Use this for local
+retailers without a dedicated pipeline (e.g. regional electronics chains).
+
+> **Pipeline names are inconsistent** (`amazon_product` singular,
+> `bestbuy_products` plural, `walmart_product`). Confirm with the type list
+> before hardcoding — the `data-feeds` skill has the verified list, and
+> keyword/multi-arg pipelines (`amazon_product_search`) take
+> `<keyword> <domain_url>`, not a single URL.
+
+## Region Handling
+
+- **Country changes everything** — price, currency, stock, and which retailers
+  exist. Always confirm the region before running; default US only if the user
+  doesn't say.
+- **Pass `--country <code>`** to `bdata search` for localized SERP/shopping
+  results (e.g. `--country il` for Israel, `de`, `uk`).
+- **Use the local Amazon domain** in product URLs. Many regions (e.g. Israel)
+  buy via `amazon.com` with international shipping *and* via local chains —
+  cover both and label shipping/import implications.
+- **Normalize currencies** to one display currency, state the rate and the date
+  you used, and keep each offer's original-currency price in the dataset.
+
+## Output
+
+Read [references/output-and-pricing.md](references/output-and-pricing.md) for:
+- The **normalized offer record** schema (row shape for both the table and the
+  dataset output).
+- **Total-cost ranking** rules (price + shipping + import/tax where known;
+  in-stock and condition gates before declaring a winner).
+- **Currency normalization** conventions.
+- **Output templates** — A (comparison table + recommendation), B (structured
+  dataset), C (both).
+
+## Output Quality Standards
+
+1. **Every price has a source URL and a timestamp** — no undated, unattributed
+   prices.
+2. **Always show availability next to price** — a cheaper out-of-stock offer is
+   not the winner. Flag refurbished/used/third-party explicitly.
+3. **Name one "Best buy"** — the cheapest *in-stock, comparable-condition*
+   option, with the runner-up and why someone might pick it instead.
+4. **Be honest about gaps** — list retailers that returned nothing or were
+   gated this run. Note when a price looks stale or is a "from" range.
+5. **State currency and region** — "$ USD · region: US" or the rate used for
+   conversions.
+6. **Never estimate a missing price.** Report the gap; don't fill it.

--- a/skills/price-comparison/references/output-and-pricing.md
+++ b/skills/price-comparison/references/output-and-pricing.md
@@ -1,0 +1,118 @@
+# Offers, ranking & output formats
+
+## Normalized offer record
+
+Collapse every raw retailer result into this schema before comparing. This is
+also the row shape for the structured-dataset output.
+
+| Field | Notes |
+|---|---|
+| `retailer` | amazon / walmart / ebay / bestbuy / google_shopping / <local> |
+| `seller` | first-party retailer vs third-party marketplace seller (or "n/a") |
+| `title` | product title as listed (catch mismatched variants/sizes) |
+| `price` | numeric, in the listing's original currency |
+| `currency` | ISO code of `price` (USD, ILS, EUR, …) |
+| `price_display` | price normalized to the user's display currency |
+| `shipping` | shipping cost if known (0 = free, null = unknown) |
+| `total` | `price_display` + shipping (+ import/tax if known) — the ranking key |
+| `availability` | in_stock / out_of_stock / preorder / limited |
+| `condition` | new / refurbished / used / open_box |
+| `rating` | star rating + review count if available |
+| `url` | direct link to the offer — **required**, never blank |
+| `collected_at` | ISO timestamp the price was pulled |
+
+## Ranking method (and guardrails)
+
+- **Rank by `total` (landed cost), not sticker `price`.** A $10-cheaper item
+  with $25 shipping loses. When shipping/tax is unknown, rank by price but flag
+  the unknown explicitly — don't silently assume free shipping.
+- **Gate before crowning a winner.** The "Best buy" must be `in_stock` and the
+  same `condition` class the user wants (default: new). A cheaper
+  out-of-stock / refurbished / used offer is listed but not the default pick;
+  call it out as an alternative with its caveat.
+- **Watch for variant mismatch.** Different storage/size/color/bundle are
+  different products — only compare like-for-like. Note mismatches instead of
+  ranking across them.
+- **Flag third-party sellers.** A marketplace seller undercutting the
+  first-party listing carries different return/warranty risk — surface it.
+- Keep facts (the listed price + stock) separate from interpretation (your
+  "best buy" call).
+
+## Currency normalization
+
+- Convert every offer to one display currency (`price_display`). State the rate
+  and the date used, e.g. "converted at 1 USD = 3.7 ILS (2026-05-31)".
+- Keep each offer's original `price` + `currency` in the dataset so the user can
+  verify against the source page.
+- For regions where the user buys both locally and via import (e.g. Israel via
+  `amazon.com`), show landed cost including estimated shipping/import where
+  known, and label it as an estimate.
+
+---
+
+## Output A — Comparison table + recommendation
+
+```markdown
+# Price Comparison: <product>
+*Prices collected on <date> · region: <country> · display currency: <CUR>*
+
+| Retailer | Price | Shipping | Total | Availability | Condition | Rating | Link |
+|---|---|---|---|---|---|---|---|
+| Walmart | $979 | Free | **$979** | In stock | New | — | [link](url) |
+| Amazon | $999 | Free | $999 | In stock | New | 4.7★ (12k) | [link](url) |
+| eBay | $940 | $15 | $955 | In stock | Refurbished | 4.5★ | [link](url) |
+| Best Buy | $999 | Free | $999 | Out of stock | New | 4.6★ | [link](url) |
+
+## Best buy
+- **<Retailer> — $<total>**: cheapest in-stock, new. <one-line why.> [link](url)
+- Runner-up: <Retailer> at $<total> — pick this if <reason, e.g. faster
+  shipping / better return policy / higher rating>.
+- Cheaper-but-caveated: <eBay refurbished $955> — only if you're OK with
+  refurbished/no manufacturer warranty.
+
+## Gaps & caveats
+- Retailers with no result this run: <list>.
+- Prices/currency notes: <conversion rate used; any "from" ranges or stale data>.
+```
+
+Every report **must** end by naming a single best in-stock buy (or stating that
+nothing comparable is in stock). A table with no recommendation is not a
+deliverable.
+
+## Output B — Structured dataset
+
+One row per normalized offer.
+
+```bash
+# Pipelines can emit CSV directly:
+bdata pipelines amazon_product "<url>" --format csv -o amazon_offer.csv
+# Then merge retailer files and add total/condition/availability columns
+# during normalization.
+```
+
+JSON shape:
+```json
+[
+  {
+    "retailer": "amazon",
+    "seller": "Amazon.com",
+    "title": "Apple iPhone 17 Pro 256GB",
+    "price": 999.00,
+    "currency": "USD",
+    "price_display": 999.00,
+    "shipping": 0,
+    "total": 999.00,
+    "availability": "in_stock",
+    "condition": "new",
+    "rating": {"stars": 4.7, "reviews": 12043},
+    "url": "https://www.amazon.com/dp/...",
+    "collected_at": "2026-05-31T00:00:00Z"
+  }
+]
+```
+
+## Output C — Both
+
+Deliver the dataset (B) as the evidence layer and the comparison table +
+recommendation (A) built on top, with each table row linking back to its
+dataset entry.


### PR DESCRIPTION
## Summary

Adds skills for specific flows to the marketplace:

- **brand-listening** skill (`SKILL.md` + `references/sentiment-and-output.md`)
- **price-comparison** skill (`SKILL.md` + `references/output-and-pricing.md`)
- Registers both in `.claude-plugin/marketplace.json` and `.claude-plugin/plugin.json`
- README updates

## Notes

Submitted from a fork (`shahar-brd/skills`) since `shahar-brd` does not have direct push access to `brightdata/skills`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)